### PR TITLE
0.4 merge

### DIFF
--- a/Databases/create_databases
+++ b/Databases/create_databases
@@ -329,7 +329,7 @@ fi
 for ((j=0; j<=${DB_PER_WORKER}*${NUMBER_OF_WORKERS}-1; j++))
 do
   node_number=$((j%NUMBER_OF_WORKERS))
-  node_name=${worker_node_array[${node_number}]}
+  node_name=$(oc get node ${worker_node_array[${node_number}]} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
   pvc_name=${DB_PVC_PREFIX}-${j}
   pod_name=${DB_POD_PREFIX}-${j}
   echo "$(mydate) Creating ${DB_TYPE} database pod ${pod_name} on node ${node_name}"

--- a/Databases/run_database_workload-parallel
+++ b/Databases/run_database_workload-parallel
@@ -30,9 +30,9 @@ fi
 
 if [[ -z ${RUN_NAME} ]]; then
   if [ "$(uname -s)" == "Linux" ];then
-    RUN_NAME=$(cat /dev/random | tr -dc "[:lower:]" | head -c 6)
+    RUN_NAME=$(cat /dev/urandom | tr -dc "[:lower:]" | head -c 6)
   else
-    RUN_NAME=$(cat /dev/random | LC_CTYPE=C tr -dc "[:lower:]" | head -c 6)
+    RUN_NAME=$(cat /dev/urandom | LC_CTYPE=C tr -dc "[:lower:]" | head -c 6)
   fi
 fi
 
@@ -85,7 +85,7 @@ function get_rbd_list()
   done
   for node_name in $(cat $WORKERS_LIST_FILE)
   do
-    local_node_name=$(oc get node ${node_name} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
+    local host_name=$(oc get node ${node_name} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
     rbd_line=""
     node_pvc=$(oc debug node/${node_name} -- lsblk | grep rbd | awk '{print $1"@@"$7}')
     for lsblk_line in $(echo ${node_pvc})
@@ -99,7 +99,7 @@ function get_rbd_list()
       done
     done
     rbd_line=${rbd_line#?}
-    worker_rbd[${local_node_name}]=${rbd_line}
+    worker_rbd[${host_name}]=${rbd_line}
   done
 }
 
@@ -166,10 +166,33 @@ job_name=$(echo ${job_name} | awk '{print $1}')
 workload_pod_name=$(${KUBE_CMD} describe ${job_name} | grep "Created pod:" | awk -F "Created pod: " '{print $2}')
 }
 
+function find_taints()
+{
+ local node_name="${1}"
+ local node_taint=$(oc get node ${node_name} -o jsonpath='{.spec.taints[0].effect}{"ZZZ"}{.spec.taints[0].key}{"ZZZ"}{.spec.taints[0].value}')
+ if [[ ${node_taint} != "ZZZZZZ" ]];then
+   toleration_effect=$(echo "${node_taint}" | awk -F"ZZZ" '{print $1}')
+   toleration_key=$(echo "${node_taint}" | awk -F"ZZZ" '{print $2}')
+   toleration_value=$(echo "${node_taint}" | awk -F"ZZZ" '{print $3}')
+   if [[ "${toleration_value}" == "" ]]; then
+     toleration=$(echo -e "tolerations:\n      - key: \"${toleration_key}\"\n        operator: \"Exists\"\n        effect: ${toleration_effect}")
+   else
+     toleration=$(echo -e "tolerations:\n      - key: \"${toleration_key}\"\n        value: \"${toleration_value}\"\n        effect: ${toleration_effect}")
+   fi
+ fi
+ 
+ echo "${toleration}"
+}
+
 function run_stats()
 {
-  local node_name=$(oc get node ${node_name} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
+  local toleration=""
   local node_type="${1}"
+  if [[ "${SDS_NODE_TAINTED}" == "true" && "${node_type}" == "sds" ]]; then
+    echo "$(mydate) Checking for tolerations in sds node ${node_name}..."
+    toleration=$(find_taints ${node_name})
+  fi  
+  local node_name=$(oc get node ${node_name} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
   job_name=$(cat <<EOF | ${KUBE_CMD} create -f -
 apiVersion: batch/v1
 kind: Job
@@ -178,6 +201,7 @@ metadata:
 spec:
   template:
     spec:
+      ${toleration}
       hostNetwork: true
       restartPolicy: Never
       nodeSelector:
@@ -197,17 +221,6 @@ EOF
 )
 job_name=$(echo ${job_name} | awk '{print $1}')
 stats_pod_name=$(${KUBE_CMD} describe ${job_name} | grep "Created pod:" | awk -F "Created pod: " '{print $2}')
-}
-
-function cordon_control()
-{
-  local cordon_command=${1}
-  local cordon_node=${2}
-  if [[ "${cordon_command}" == "cordon" ]]; then
-    [[ "${KUBE_CMD}" == "oc" ]] && ${KUBE_CMD} adm cordon ${cordon_node} || ${KUBE_CMD} cordon ${cordon_node}
-  else
-    [[ "${KUBE_CMD}" == "oc" ]] && ${KUBE_CMD} adm uncordon ${cordon_node} || ${KUBE_CMD} uncordon ${cordon_node}
-  fi
 }
 
 function stats_collect()
@@ -299,10 +312,12 @@ if [[ "${JOB_TYPE}" == "run" ]];then
     get_rbd_list
     for node_ip in ${!worker_rbd[@]}
     do
-      file_name=$(ls ${RUN_NAME}/stats-${RUN_NAME}-worker-${node_ip}*.log)
+      file_name=$(ls ${RUN_NAME}/stats-worker-${RUN_NAME}-${node_ip}*.log)
       rbd_device="${worker_rbd[${node_ip}]}"
       calculate_rbd_utilization ${file_name} "${rbd_device}"
     done
   fi
+else
+  echo "$(mydate) Jobs are running in the background. Use \"${KUBE_CMD} get jobs\" to monitor the jobs..."
 fi
 echo "$(mydate) End of $0 script ..."

--- a/Databases/sherlock.config
+++ b/Databases/sherlock.config
@@ -5,11 +5,11 @@
 # 
 
 # How long the workload will run in seconds (must be >= 60 for hammerdb)
-readonly WORKLOAD_RUNTIME=300
+readonly WORKLOAD_RUNTIME=120
 
 # How many connections to open to each database. for sysbench and pgbench usage
-readonly THREADS=6
-readonly CLIENTS=6
+readonly THREADS=2
+readonly CLIENTS=2
 readonly OUTPUT_INTERVAL=10  # in seconds
 
 # for PostgreSQL using sysbench 400 tables, each with 1000000 rows is roughly 100G in DB size
@@ -63,7 +63,7 @@ readonly KUBE_CMD=oc
 readonly NUMBER_OF_WORKERS=3
 
 # How many databases to create per worker node
-readonly DB_PER_WORKER=4
+readonly DB_PER_WORKER=1
 
 # List of nodes that will run the databases
 readonly WORKERS_LIST_FILE=~/workers
@@ -73,7 +73,7 @@ readonly SDS_LIST_FILE=~/sds_nodes
 
 # Set the project or namespace that will be used to run all the sherlock pods. If PROJECT_NAME does not exists, it will be created.
 # For convenience, I recommend using postgresql, mysql or sqlserver, but these names are not hardcoded and you can use whatever you choose.
-readonly PROJECT_NAME=sqlserver 
+readonly PROJECT_NAME=mysql 
 
 
 #
@@ -81,16 +81,16 @@ readonly PROJECT_NAME=sqlserver
 #
 
 # What type of database we are using: postgresql, mysql or sqlserver
-readonly DB_TYPE=sqlserver
+readonly DB_TYPE=mysql
 
 # This prefix will be added to any sherlock pod for better detection. 
 # For convenience, I recommend using postgresql, mysql or sqlserver, but these names are not hardcoded and you can use whatever you choose.
-readonly DB_POD_PREFIX=sqlserver
+readonly DB_POD_PREFIX=mysql
 
 
 # This prefix will be added to any PVC created by sherlock for better detection. 
 # For convenience, I recommend using postgresql, mysql or sqlserver, but these names are not hardcoded and you can use whatever you choose.
-readonly DB_PVC_PREFIX=sqlserver-pvc
+readonly DB_PVC_PREFIX=mysql-pvc
 
 # the size of PVC created for each database. make sure your SDS have enough storage to support PVC_SIZE * DB_PER_WORKER * NUMBER_OF_WORKERS
 readonly PVC_SIZE=50Gi
@@ -128,8 +128,11 @@ readonly SDS_DEVICES="nvme0n1 nvme1n1"
 # list of the sds network interface/s (seperated by space) that are used by the SDS. These are only being monitored on nodes in SDS_LIST_FILE.
 readonly SDS_NETWORK_INTERFACES="eth0" 
 
-# For OCS or Rook/Ceph, you can set this to true and IO stats will be calculted of each RBD PVC that is used by each database on each worker node. For other SDS, set to false.
+# OpenShift Only. For OCS or Rook/Ceph, you can set this to true and IO stats will be calculted of each RBD PVC that is used by each database on each worker node. For other SDS, set to false.
 readonly RBD_STATS=false
 
 # script related
 readonly DEBUG=false
+
+# in some cases nodes running the SDS will be tainted, sherlock will *try* to match the first taint and apply it to the stats pods
+readonly SDS_NODE_TAINTED=true


### PR DESCRIPTION
1. Changed /dev/random to /dev/urandom
2. Added print explain how to monitor "prepare" and "cleanup" jobs
3. Removing cordon_control function
4. create_database now using kubernetes.io/hostname when placing the DB pods.
5. If SDS node have taints, the run_database_workload-parallel script will try to add the toleration to the stats pods running on SDS nodes.