### PR TITLE
Fixes issue of long node names causing job names to trim

### DIFF
--- a/Databases/print_results
+++ b/Databases/print_results
@@ -83,45 +83,6 @@ function print_hammerdb_results_per_single_run()
     esac
 }
 
-function print_sysbench_results_per_single_run()
-{
-  local run_dir=${1}
-  let total_tps=0
-  let total_avg_latency=0
-  let total_latency_95=0
-  let number_of_logs_file=0
-  while read line
-  do
-    tps=$(echo "${line}" | awk -F'@' '{print $1}' | awk '{print $4}' | tr -d '(')
-    avg_latency=$(echo "${line}" | awk -F'@' '{print $2}' | awk '{print $3}' | tr -d ' ')
-    latency_95=$(echo "${line}" | awk -F'@' '{print $3}' | awk '{print $4}' | tr -d ' ')
-    total_tps=$(echo "${total_tps}" + "${tps}"|bc)
-    total_avg_latency=$(echo "${total_avg_latency}" + "${avg_latency}"|bc)
-    total_latency_95=$(echo "${total_latency_95}" + "${latency_95}"|bc)
-    (( number_of_logs_file++ ))
-  done < <(grep 'transactions\|avg:\|percentile:' ${run_dir}/*.log|grep -v CLEANUP|paste -d "@" - - -)
-  case "${OUTPUT_TYPE}" in
-    csv)
-      echo "${run_dir},$(echo "scale=2;${total_tps}"/"${number_of_logs_file}"|bc),$(echo "scale=2;${total_avg_latency}"/"${number_of_logs_file}"|bc),$(echo "scale=2;${total_latency_95}"/"${number_of_logs_file
-}"|bc)"
-      ;;
-    table)
-      echo "${run_dir},$(echo "scale=2;${total_tps}"/"${number_of_logs_file}"|bc),$(echo "scale=2;${total_avg_latency}"/"${number_of_logs_file}"|bc),$(echo "scale=2;${total_latency_95}"/"${number_of_logs_file
-}"|bc)" | awk -F, '{printf "|%-10s|%-15s|%-17s|%17-s|\n", $1, $2, $3, $4}'
-      ;;
-    simple)
-      echo "Run name: ${run_dir}"
-      echo "Average TPS for all databases: $(echo "scale=2;${total_tps}"/"${number_of_logs_file}"|bc)"
-      echo "Average latency for all databases: $(echo "scale=2;${total_avg_latency}"/"${number_of_logs_file}"|bc)"
-      echo "Average 95% latency for all databases: $(echo "scale=2;${total_latency_95}"/"${number_of_logs_file}"|bc)"
-      ;;
-    *)
-      echo "Unknown output type"
-      exit 1
-      ;;
-    esac
-}
-
 function print_ycsb_results_per_single_run()
 {
   local run_dir=${1}
@@ -170,35 +131,54 @@ function print_ycsb_results_per_single_run()
 function print_perf_results()
 {
   local run_dir=${1}
+  echo "local run_dir=${run_dir}"
   source ${run_dir}/${CONFIG_FILE} > /dev/null 2>&1
+  if [ "$(uname -s)" == "Linux" ];then
+    if [[ "${WORKERS_LIST_FILE}" == "${SDS_LIST_FILE}" ]]; then
+      mapfile -t sds_node_array < <(cat ${run_dir}/$(basename ${WORKERS_LIST_FILE}))
+    else
+      mapfile -t worker_node_array < <(cat ${run_dir}/$(basename ${WORKERS_LIST_FILE}))
+      mapfile -t sds_node_array < <(cat ${run_dir}/$(basename ${SDS_LIST_FILE}))
+    fi
+  else
+    if [[ "${WORKERS_LIST_FILE}" == "${SDS_LIST_FILE}" ]]; then
+      declare -a worker_node_array
+      while IFS= read -r line; do sds_node_array+=("$line"); done < <(cat ${LOG_DIR}/${WORKERS_LIST_FILE})
+    else
+      declare -a worker_node_array
+      while IFS= read -r line; do worker_node_array+=("$line"); done < <(cat ${LOG_DIR}/${WORKERS_LIST_FILE})
+      declare -a sds_node_array
+      while IFS= read -r line; do sds_node_array+=("$line"); done < <(cat ${LOG_DIR}/${SDS_LIST_FILE})
+    fi
+  fi
   
   if [[ "${WORKERS_LIST_FILE}" != "${SDS_LIST_FILE}" ]]; then
     echo "Worker nodes:"
     echo "-------------"
-    for nodename in $(cat ${WORKERS_LIST_FILE})
+    for node_number in ${!worker_node_array[@]}
     do
-      local node_name=$(oc get node ${nodename} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
-      echo "${nodename}:"
-      grep SUMMARY ${run_dir}/stats-worker-*-${node_name}*.log | awk '{$1=""; print $0}' | cut -c 2-
+      local node_name=$(oc get node ${worker_node_array[$node_number]} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
+      echo "${node_name}:"
+      grep SUMMARY ${run_dir}/stats-worker-*-node${node_number}*.log | awk '{$1=""; print $0}' | cut -c 2-
     done
     echo ""
     echo "SDS nodes:"
     echo "----------"
-    for nodename in $(cat ${SDS_LIST_FILE})
+    for node_number in ${!sds_node_array[@]}
     do
-      local node_name=$(oc get node ${nodename} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
-      echo "${nodename}:"
-      grep SUMMARY ${run_dir}/stats-sds-*-${node_name}*.log | awk '{$1=""; print $0}' | cut -c 2-
+      local node_name=$(oc get node ${sds_node_array[$node_number]} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
+      echo "${node_name}:"
+      grep SUMMARY ${run_dir}/stats-sds-*-$node{node_number}*.log | awk '{$1=""; print $0}' | cut -c 2-
     done
   else
     echo "SDS + Worker nodes:"
     echo "-------------------"
-    for nodename in $(cat ${SDS_LIST_FILE})
+    for node_number in ${!sds_node_array[@]}
     do
-      echo "nodename=${nodename}"
-      local node_name=$(oc get node ${nodename} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
-      echo "${nodename}:"
-      grep SUMMARY ${run_dir}/stats-sds-*-${node_name}*.log | awk '{$1=""; print $0}' | cut -c 2-
+      #local node_name=$(oc get node ${nodename} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
+      local node_name=$(oc get node ${sds_node_array[$node_number]} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}')
+      echo "${node_name}:"
+      grep SUMMARY ${run_dir}/stats-sds-*-node${node_number}*.log | awk '{$1=""; print $0}' | cut -c 2-
     done
   fi
 }

--- a/Databases/run_database_workload-parallel
+++ b/Databases/run_database_workload-parallel
@@ -199,7 +199,7 @@ function run_stats()
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: stats-${node_type}-${RUN_NAME}-${node_name}-
+  generateName: stats-${node_type}-${RUN_NAME}-node${node_number}-
 spec:
   template:
     spec:
@@ -230,8 +230,9 @@ function stats_collect()
   local node_type=${1}
   shift 1
   local local_array=("$@")
-  for node_name in ${local_array[@]}
+  for node_number in ${!local_array[@]}
   do
+    node_name=${local_array[${node_number}]}
     echo "$(mydate) Starting to collect stats on ${node_type} node ${node_name}..."
     run_stats "${node_type}" "${local_array[@]}"
     jobs_pods[${job_name}]=${stats_pod_name}
@@ -297,6 +298,8 @@ if [[ "${JOB_TYPE}" == "run" ]];then
   fi
 
   cp ${CONFIG_FILE} ${RUN_NAME}/
+  cp ${WORKERS_LIST_FILE} ${RUN_NAME}/
+  cp ${SDS_LIST_FILE} ${RUN_NAME}/
   job_list=""
 
   for i in "${!jobs_pods[@]}"


### PR DESCRIPTION
this cause the print_results script to fail when reading the statistics from the stats pod logs.