### PR TITLE
feat(v2): Sherlock v2 — operator-based rewrite

### DIFF
--- a/operator/crds/ADDING_A_BENCHMARK.md
+++ b/operator/crds/ADDING_A_BENCHMARK.md
@@ -1,0 +1,374 @@
+# Adding a new benchmark to Sherlock
+
+This guide walks through everything required to add a new benchmark or database
+to Sherlock v2. By the time you're done you'll have a new CRD, a container image,
+operator handlers, a stat parser, and example manifests.
+
+Use fio as the reference implementation for a pure storage benchmark, and
+pgbench as the reference for a database benchmark.
+
+---
+
+## Overview of what needs to be added
+
+```
+operator/
+  crds/
+    benchmarks/
+      <name>-suite.yaml         ← 1. CRD schema
+    examples/
+      <name>-example.yaml       ← 2. Example manifests
+containers/
+  <name>_container/
+    Dockerfile                  ← 3. Benchmark container image
+    runs/
+      run_<name>                ← 4. Benchmark entrypoint script (Bash, inside container)
+operator/
+  handlers/
+    <name>.py                   ← 5. kopf operator handler
+  parsers/
+    <name>.py                   ← 6. Python result parser
+  plugins/
+    storage/
+      generic.py                ← (shared, no change needed usually)
+```
+
+---
+
+## Step 1 — CRD schema
+
+Create `operator/crds/benchmarks/<name>-suite.yaml`.
+
+Every Sherlock Suite CRD has four required top-level sections in `spec`:
+
+### `spec.database` (DB benchmarks) or `spec.storage` (storage-only benchmarks)
+
+For a **database benchmark** (PostgreSQL, MySQL, MongoDB, MSSQL):
+- Copy the `database` block from `pgbench-suite.yaml` or `hammerdb-suite.yaml`
+- Change `type` enum to include your database engine(s)
+- Add any database-specific fields (e.g. `partitionedTables` for pgbench)
+- Keep `storageClass`, `storageSize`, `storagePlugin`, `resources`, `nodeSelector`,
+  `tolerations` identical — these are shared infrastructure fields
+
+For a **storage-only benchmark** (like fio):
+- Copy the `storage` block from `fio-suite.yaml`
+- There is no database layer, so `volumeMode` and `fioPerWorker` replace
+  `instancesPerNode`
+
+### `spec.execution`
+
+Copy verbatim from any existing CRD. This block is identical across all Suite kinds:
+```yaml
+execution:
+  order: sequential | parallel
+  sleepBetweenRuns: 30
+  failurePolicy: abortAll | retryN | continueAndReport
+  retryLimit: 3
+  timeoutPerRun: 1h
+```
+
+### `spec.sweep`
+
+This is the benchmark-specific section. Rules:
+- Every field accepts a **list of values** (`type: array`)
+- Multi-value lists become sweep axes; single-value lists are fixed params
+- Field names should map directly to the benchmark's CLI flags or config keys
+- Add a `description` to every field explaining the CLI flag it maps to
+- Include an `example:` annotation showing realistic values
+
+Checklist for sweep fields:
+- [ ] Primary scaling axis (threads, clients, virtual users, block size)
+- [ ] Workload type or mix (read/write ratio, test script, workload letter)
+- [ ] Dataset or work size
+- [ ] Duration / operation count
+- [ ] Any benchmark-specific tuning knobs worth sweeping
+
+### `spec.artifacts`
+
+Copy verbatim from any existing CRD. This block is identical across all Suite kinds.
+
+### `status` block
+
+Required fields (copy from any existing CRD):
+- `phase` — add any benchmark-specific phases if needed
+  (fio adds `Provisioning`; most DB benchmarks don't need extras)
+- `observedGeneration`
+- `runMatrix[]` with `name`, `params`, `phase`, `startTime`, `completionTime`,
+  `retryCount`, `artifactPath`, `result`
+- `summary` with `totalRuns`, `runsCompleted`, `runsFailed`, `runsRemaining`
+- `artifacts` with `pvcName`, `bundles[]`
+- `conditions[]` — use `PVCsReady` for storage benchmarks,
+  `DatabaseReady` for DB benchmarks (or add a new type if appropriate)
+
+**The `result` object is benchmark-specific.** Add fields for:
+1. The benchmark's primary output metric(s) — e.g. TPS, IOPS, ops/sec, NOPM
+2. Any secondary metrics the benchmark natively reports (latency percentiles, etc.)
+3. The shared storage metrics block (copy from any existing CRD) — these come
+   from the stat collectors, not the benchmark itself, and enable cross-suite comparison:
+   ```yaml
+   avgReadIops:   {type: number}
+   avgWriteIops:  {type: number}
+   avgReadBwMBs:  {type: number}
+   avgWriteBwMBs: {type: number}
+   avgLatencyMs:  {type: number}
+   p95LatencyMs:  {type: number}
+   p99LatencyMs:  {type: number}
+   ```
+
+### CRD naming conventions
+
+| Thing | Pattern | Example |
+|-------|---------|---------|
+| CRD filename | `<name>-suite.yaml` | `pgbench-suite.yaml` |
+| CRD metadata.name | `sherlock<name>suites.sherlock.io` | `sherlockpgbenchsuites.sherlock.io` |
+| Kind | `Sherlock<Name>Suite` | `SherlockPgbenchSuite` |
+| shortNames | `sl<abbrev>` | `slpg`, `slpgbench` |
+
+---
+
+## Step 2 — Example manifests
+
+Create `operator/crds/examples/<name>-example.yaml`.
+
+Good examples include:
+- A header comment explaining what the sweep produces (N × M = total runs)
+- A comment showing what the run names will look like
+- At least one `pvc` destination example
+- Ideally a second example showing a different destination (`s3` or `local`)
+- Realistic values — don't use toy numbers, use values that would actually be
+  useful for storage characterization
+
+---
+
+## Step 3 — Benchmark container image
+
+Create `containers/<name>_container/`.
+
+Minimum contents:
+```
+containers/<name>_container/
+  Dockerfile
+  runs/
+    run_<name>       ← entrypoint: accepts parameters, runs benchmark, writes output
+```
+
+The container must:
+- Accept all sweep parameters as positional arguments or environment variables
+- Write output to stdout (the operator captures logs) AND to a file under `/output/`
+- Exit 0 on success, non-zero on failure (the operator watches exit codes)
+- Not require network access beyond the database/storage being tested
+- Be published to `quay.io/sagyvolkov/<name>_container:<version>`
+
+For the entrypoint script, follow the existing containers:
+- `containers/fio_container/runs/run_fio` — simple, positional args, calls the tool
+- `containers/pgbench/` — two-phase (init + run)
+- `containers/hammerdb/` — TCL script generation then HammerDB execution
+
+Output format: default to JSON where the benchmark supports it (fio, sysbench).
+For tools without JSON output (pgbench, hammerdb), structured text is fine —
+the parser (Step 6) handles the extraction.
+
+---
+
+## Step 4 — Benchmark entrypoint (inside container)
+
+The `run_<name>` script inside the container should:
+
+1. Parse arguments
+2. Run any setup phase (create tables, load data, warmup)
+3. Run the benchmark
+4. Write structured output to `/output/<run_name>.json` or `/output/<run_name>.log`
+5. Print a summary to stdout with at minimum the primary metric value
+
+Keep it simple — the container script is not responsible for orchestration,
+waiting, or collecting stats. The operator and stat collectors handle those.
+
+---
+
+## Step 5 — kopf operator handler
+
+Create `operator/handlers/<name>.py`.
+
+The handler registers three kopf event handlers for your new Suite kind:
+
+```python
+import kopf
+from operator.matrix import expand_cartesian
+from operator.runners import run_benchmark_job, collect_artifacts
+from operator.parsers import <name> as parser
+
+@kopf.on.create('sherlock.io', 'v1alpha1', 'Sherlock<Name>Suite')
+def on_create(spec, name, namespace, patch, **kwargs):
+    """
+    Called when a new SherlockXxxSuite CR is created.
+    Responsibilities:
+    1. Expand spec.sweep into the run matrix
+    2. Write matrix to status.runMatrix
+    3. Create database/storage infrastructure (PVCs, DB pods)
+    4. Set status.phase = Deploying
+    """
+    matrix = expand_cartesian(spec['sweep'])
+    patch.status['runMatrix'] = [{'name': make_run_name(name, p), 'params': p,
+                                   'phase': 'Pending'} for p in matrix]
+    patch.status['phase'] = 'Deploying'
+    patch.status['summary'] = {'totalRuns': len(matrix), 'runsCompleted': 0,
+                                'runsFailed': 0, 'runsRemaining': len(matrix)}
+
+@kopf.on.field('sherlock.io', 'v1alpha1', 'Sherlock<Name>Suite',
+               field='status.phase')
+def on_phase_change(old, new, spec, name, namespace, patch, **kwargs):
+    """
+    Drives the state machine: Ready → Running → Sleeping → Running → ... → Completed
+    Called whenever status.phase changes.
+    """
+    if new == 'Ready':
+        start_next_run(spec, name, namespace, patch)
+
+@kopf.on.event('', 'v1', 'pods',
+               labels={'sherlock.io/suite-name': kopf.PRESENT})
+def on_pod_event(event, name, namespace, patch, **kwargs):
+    """
+    Watches Job pods for completion/failure.
+    On completion: collect artifacts, parse results, advance to next run.
+    On failure: apply failurePolicy (abort/retry/continue).
+    """
+    ...
+```
+
+The `expand_cartesian` utility in `operator/matrix.py` is shared — it takes
+the sweep dict and returns a list of parameter dicts, one per combination.
+Your handler does not need to implement this.
+
+Key labels to set on all Jobs and pods created by your handler:
+```python
+labels = {
+    'sherlock.io/suite-name': name,
+    'sherlock.io/suite-kind': 'Sherlock<Name>Suite',
+    'sherlock.io/run-name': run_name,
+}
+```
+These labels are how the operator finds pods to watch and how artifacts are
+associated with the right run.
+
+---
+
+## Step 6 — Python result parser
+
+Create `operator/parsers/<name>.py`.
+
+The parser has one required function:
+
+```python
+def parse(raw_output: str, params: dict) -> dict:
+    """
+    Parse raw benchmark output (stdout log from the container) into a
+    structured result dict matching the CRD status.runMatrix[].result schema.
+
+    Args:
+        raw_output: full stdout from the benchmark container pod log
+        params: the resolved parameter dict for this run (from runMatrix[].params)
+
+    Returns:
+        dict with keys matching status.runMatrix[].result fields.
+        Always include the primary metric. Leave unknown fields absent
+        rather than setting them to 0 — the operator handles missing fields.
+    """
+    ...
+    return {
+        'tps': ...,             # your benchmark's primary metric key
+        'latencyAvgMs': ...,
+        'latencyP95Ms': ...,
+    }
+```
+
+And one optional function for stat-collector output (same across all parsers,
+but you can override if needed):
+
+```python
+def parse_storage_stats(iostat_output: str, vmstat_output: str) -> dict:
+    """
+    Parse iostat/vmstat output from the stat collector pod into storage metrics.
+    The default implementation in operator/parsers/base.py handles this for
+    most cases — only override if your storage plugin produces different output.
+    """
+    from operator.parsers.base import parse_storage_stats as default
+    return default(iostat_output, vmstat_output)
+```
+
+Parser tips:
+- fio with `--output-format=json`: use `json.loads()`, extract
+  `jobs[0]['read']['iops']`, `jobs[0]['read']['lat_ns']['percentile']`, etc.
+- pgbench: regex for `tps = \d+\.\d+` in the last line of output
+- sysbench: regex for `transactions: \d+ \(\d+\.\d+ per sec\)`
+- hammerdb: parse the `NOPM` value from the HammerDB result line
+- Always strip ANSI escape codes before parsing: `re.sub(r'\x1b\[[0-9;]*m', '', raw)`
+
+---
+
+## Step 7 — Register the new CRD in the operator
+
+Add your new kind to `operator/main.py`:
+
+```python
+# operator/main.py
+import operator.handlers.hammerdb
+import operator.handlers.pgbench
+import operator.handlers.sysbench
+import operator.handlers.ycsb
+import operator.handlers.fio
+import operator.handlers.<name>    # ← add this line
+```
+
+kopf auto-discovers handlers via the decorators, but the module must be imported
+for the decorators to run.
+
+---
+
+## Step 8 — Update the CRD README
+
+Add your new benchmark to the table in `operator/crds/README.md`:
+
+```markdown
+| `Sherlock<Name>Suite` | <benchmark tool> | <database/storage> |
+```
+
+And add its primary metric to the metrics table.
+
+---
+
+## Checklist
+
+Before opening a PR:
+
+- [ ] `operator/crds/benchmarks/<name>-suite.yaml` — CRD schema
+- [ ] `operator/crds/examples/<name>-example.yaml` — at least one working example
+- [ ] `containers/<name>_container/Dockerfile` — container image definition
+- [ ] `containers/<name>_container/runs/run_<name>` — benchmark entrypoint
+- [ ] `operator/handlers/<name>.py` — kopf handler
+- [ ] `operator/parsers/<name>.py` — result parser
+- [ ] `operator/main.py` updated to import new handler
+- [ ] `operator/crds/README.md` updated with new benchmark
+- [ ] Container image built and pushed to `quay.io/sagyvolkov/<name>_container:<version>`
+- [ ] `kubectl apply -f operator/crds/benchmarks/<name>-suite.yaml` succeeds
+- [ ] `kubectl apply -f operator/crds/examples/<name>-example.yaml` succeeds
+- [ ] At least one successful end-to-end test run with artifacts collected
+
+---
+
+## A note on database vs. storage-only benchmarks
+
+The main structural difference in the CRD:
+
+| | DB benchmark | Storage-only (fio) |
+|--|--|--|
+| Top-level infra section | `spec.database` | `spec.storage` |
+| Infrastructure phase | DB pod scheduling + readiness | PVC provisioning only |
+| `conditions[].type` | `DatabaseReady` | `PVCsReady` |
+| Container image purpose | connect to DB, run queries | write directly to PVC |
+| Two-phase setup | yes (init schema + load data, then benchmark) | no (fio writes its own data) |
+
+If your benchmark connects to a database that Sherlock already deploys (PostgreSQL,
+MySQL, MongoDB, MSSQL), reuse the existing DB deployment logic in the operator —
+don't re-implement it. The handler for your benchmark should call the shared
+`operator.db.deploy(db_type, spec)` function and wait for `DatabaseReady` before
+starting benchmark jobs.

--- a/operator/crds/README.md
+++ b/operator/crds/README.md
@@ -11,19 +11,37 @@ the nested for-loop pattern from the original shell scripts.
 ```
 operator/crds/
   base/
-    common-types.yaml         # Shared field documentation (DatabaseSpec, ExecutionSpec,
-                              # ArtifactSpec) — not a standalone CRD
+    common-types.yaml             # Shared field documentation (not a standalone CRD)
   benchmarks/
-    hammerdb-suite.yaml       # SherlockHammerDBSuite — MSSQL / MySQL via HammerDB TPC-C
-    pgbench-suite.yaml        # SherlockPgbenchSuite  — PostgreSQL via pgbench
-    sysbench-suite.yaml       # SherlockSysbenchSuite — MySQL / PostgreSQL via sysbench
-    ycsb-suite.yaml           # SherlockYCSBSuite     — MongoDB via YCSB
+    fio-suite.yaml                # SherlockFioSuite      — fio (any PVC, block or filesystem)
+    hammerdb-suite.yaml           # SherlockHammerDBSuite — MSSQL / MySQL via HammerDB TPC-C
+    pgbench-suite.yaml            # SherlockPgbenchSuite  — PostgreSQL via pgbench
+    sysbench-suite.yaml           # SherlockSysbenchSuite — MySQL / PostgreSQL via sysbench
+    ycsb-suite.yaml               # SherlockYCSBSuite     — MongoDB via YCSB
   examples/
-    hammerdb-example.yaml     # 6-run VU sweep, PVC artifact destination
-    pgbench-example.yaml      # 12-run rw-ratio sweep, S3 artifact destination
-    sysbench-example.yaml     # 8-run thread sweep, PVC + retryN failure policy
-    ycsb-example.yaml         # 9-run workload sweep, local pull destination
+    fio-example.yaml              # Block mode NVMe-oF sweep + filesystem throughput sweep
+    hammerdb-example.yaml         # 6-run VU sweep, PVC artifact destination
+    pgbench-example.yaml          # 12-run rw-ratio sweep, S3 artifact destination
+    sysbench-example.yaml         # 8-run thread sweep, PVC + retryN failure policy
+    ycsb-example.yaml             # 9-run workload sweep, local pull destination
+  README.md                       # This file
+  ADDING_A_BENCHMARK.md           # Guide for contributing new benchmarks
 ```
+
+## Benchmarks
+
+| CRD | Kind | Benchmark tool | Target |
+|-----|------|----------------|--------|
+| `fio-suite.yaml` | `SherlockFioSuite` | fio | Any PVC (block or filesystem) |
+| `hammerdb-suite.yaml` | `SherlockHammerDBSuite` | HammerDB TPC-C | MSSQL, MySQL |
+| `pgbench-suite.yaml` | `SherlockPgbenchSuite` | pgbench | PostgreSQL |
+| `sysbench-suite.yaml` | `SherlockSysbenchSuite` | sysbench | MySQL, PostgreSQL |
+| `ycsb-suite.yaml` | `SherlockYCSBSuite` | YCSB | MongoDB |
+
+> **fio is the only benchmark without a database layer.** It writes directly to PVCs
+> and is the best tool for raw storage characterization before introducing a database.
+> Run fio first to establish a storage baseline, then run the DB benchmarks on the
+> same storage class to understand the database overhead.
 
 ## How the parameter sweep works
 
@@ -34,14 +52,23 @@ one run per combination. This replaces the nested `for` loops in the original sc
 ```yaml
 # HammerDB example: 3 × 2 = 6 runs
 sweep:
-  virtualUsers: [8, 16, 32]   # sweep axis
-  warehouses:   [100]         # fixed param
-  rampupMins:   [2]           # fixed param
-  testMins:     [5, 10]       # sweep axis
+  virtualUsers: [8, 16, 32]   # sweep axis (3 values)
+  warehouses:   [100]         # fixed param (1 value)
+  rampupMins:   [2]           # fixed param (1 value)
+  testMins:     [5, 10]       # sweep axis (2 values)
+```
+
+```yaml
+# fio example: 5 × 3 = 15 runs
+sweep:
+  blockSize:   ["4k", "8k", "64k", "128k", "1m"]   # sweep axis (5 values)
+  rwMixWrite:  [0, 30, 100]                          # sweep axis (3 values)
+  ioPattern:   [randrw]                              # fixed param (1 value)
+  runtime:     [60]                                  # fixed param (1 value)
 ```
 
 Run names are auto-generated from axis values:
-`mssql-vu-sweep-vu8-wh100-rm2-tm5`, `mssql-vu-sweep-vu8-wh100-rm2-tm10`, ...
+`nvme-bs-sweep-bs4k-rw0-randrw-rt60-j4-qd4-2048g`
 
 ## Artifact destinations
 
@@ -58,14 +85,23 @@ kubectl sherlock pull <suite-name> ./results/
 
 ## Storage plugins
 
-The `spec.database.storagePlugin` field controls storage-side metric collection:
+The `spec.database.storagePlugin` (or `spec.storage.storagePlugin` for fio) field
+controls storage-side metric collection alongside the benchmark:
 
 | plugin    | How metrics are collected                          |
 |-----------|----------------------------------------------------|
-| generic   | iostat/vmstat on nodes where DB pods run (default) |
-| lightbits | lbcli + generic                                    |
-| odf       | ceph CLI + generic                                 |
-| portworx  | pxctl + generic                                    |
+| generic   | iostat/vmstat on nodes where pods run (default)    |
+| lightbits | lbcli stats + generic                              |
+| odf       | ceph CLI stats + generic                           |
+| portworx  | pxctl stats + generic                              |
+
+## Failure policies
+
+| policy | Behaviour |
+|--------|-----------|
+| `abortAll` | Cancel all remaining runs on first failure |
+| `retryN` | Retry failed run up to `retryLimit` times, then abort |
+| `continueAndReport` | Continue remaining runs, mark suite `Degraded` at end |
 
 ## Phase state machine
 
@@ -75,18 +111,34 @@ Pending → Deploying → Ready → Running ⇄ Sleeping → Collecting → Comp
                                 Failed                           Degraded
 ```
 
+fio adds a `Provisioning` phase between `Pending` and `Ready` to account for
+large block PVC provisioning time.
+
 ## Benchmark-specific primary metrics
 
-| Benchmark | Primary metric       | Storage metrics (all benchmarks)     |
-|-----------|----------------------|--------------------------------------|
-| HammerDB  | nopm, tpm            | avgReadIops, avgWriteIops,           |
-| pgbench   | tps                  | avgReadBwMBs, avgWriteBwMBs,         |
-| sysbench  | tps, qps             | avgLatencyMs, p95LatencyMs,          |
-| YCSB      | throughputOpsPerSec  | p99LatencyMs                         |
+| Benchmark | Primary metric(s)    | Latency unit | Storage metrics (all) |
+|-----------|----------------------|--------------|----------------------|
+| fio       | readIops, writeIops, readBwMBs, writeBwMBs | microseconds (from fio JSON) | avgReadIops, avgWriteIops, avgReadBwMBs, avgWriteBwMBs, avgLatencyMs, p95LatencyMs, p99LatencyMs |
+| HammerDB  | nopm, tpm            | —            | (same) |
+| pgbench   | tps                  | milliseconds | (same) |
+| sysbench  | tps, qps             | milliseconds | (same) |
+| YCSB      | throughputOpsPerSec  | microseconds | (same) |
+
+The shared storage metrics (rightmost column) come from stat collector pods running
+iostat/vmstat on the same nodes, enabling cross-suite storage comparison.
+
+## Adding a new benchmark
+
+See [ADDING_A_BENCHMARK.md](./ADDING_A_BENCHMARK.md) for a complete guide covering:
+- CRD schema conventions
+- Container image structure
+- kopf operator handler pattern
+- Python result parser interface
+- End-to-end checklist
 
 ## Future / reserved fields
 
-- `spec.database.partitionedTables` (pgbench) — PostgreSQL partitioned table support via CNPG
-- `spec.database.partitionMethod` (pgbench) — range | hash
-- Prometheus/Grafana observability integration (Phase 2)
+- `spec.database.partitionedTables` (pgbench) — PostgreSQL partitioned table support
+- `spec.database.partitionMethod` (pgbench) — range | hash partition strategy
+- Prometheus/Grafana observability integration (Phase 2 observability)
 - Full storage plugin implementations beyond `generic`

--- a/operator/crds/README.md
+++ b/operator/crds/README.md
@@ -1,0 +1,92 @@
+# Sherlock v2 — CRD Schemas
+
+This directory contains the CustomResourceDefinition schemas for Sherlock v2.
+
+Sherlock v2 replaces the original bash-based orchestration with a Kubernetes operator.
+Each benchmark gets its own Suite CRD with a typed parameter sweep model that mirrors
+the nested for-loop pattern from the original shell scripts.
+
+## Directory structure
+
+```
+operator/crds/
+  base/
+    common-types.yaml         # Shared field documentation (DatabaseSpec, ExecutionSpec,
+                              # ArtifactSpec) — not a standalone CRD
+  benchmarks/
+    hammerdb-suite.yaml       # SherlockHammerDBSuite — MSSQL / MySQL via HammerDB TPC-C
+    pgbench-suite.yaml        # SherlockPgbenchSuite  — PostgreSQL via pgbench
+    sysbench-suite.yaml       # SherlockSysbenchSuite — MySQL / PostgreSQL via sysbench
+    ycsb-suite.yaml           # SherlockYCSBSuite     — MongoDB via YCSB
+  examples/
+    hammerdb-example.yaml     # 6-run VU sweep, PVC artifact destination
+    pgbench-example.yaml      # 12-run rw-ratio sweep, S3 artifact destination
+    sysbench-example.yaml     # 8-run thread sweep, PVC + retryN failure policy
+    ycsb-example.yaml         # 9-run workload sweep, local pull destination
+```
+
+## How the parameter sweep works
+
+Every Suite CRD has a `spec.sweep` section where each field takes a list of values.
+The operator computes the **cartesian product** of all multi-value fields, generating
+one run per combination. This replaces the nested `for` loops in the original scripts.
+
+```yaml
+# HammerDB example: 3 × 2 = 6 runs
+sweep:
+  virtualUsers: [8, 16, 32]   # sweep axis
+  warehouses:   [100]         # fixed param
+  rampupMins:   [2]           # fixed param
+  testMins:     [5, 10]       # sweep axis
+```
+
+Run names are auto-generated from axis values:
+`mssql-vu-sweep-vu8-wh100-rm2-tm5`, `mssql-vu-sweep-vu8-wh100-rm2-tm10`, ...
+
+## Artifact destinations
+
+| type  | Where data goes              | Best for                           |
+|-------|------------------------------|------------------------------------|
+| pvc   | PVC on the cluster           | In-cluster access, CI pipelines    |
+| s3    | S3-compatible object storage | Long-term archiving, multi-cluster |
+| local | emptyDir, user pulls it      | Laptop/workstation, quick tests    |
+
+```bash
+# Pull artifacts locally after a run
+kubectl sherlock pull <suite-name> ./results/
+```
+
+## Storage plugins
+
+The `spec.database.storagePlugin` field controls storage-side metric collection:
+
+| plugin    | How metrics are collected                          |
+|-----------|----------------------------------------------------|
+| generic   | iostat/vmstat on nodes where DB pods run (default) |
+| lightbits | lbcli + generic                                    |
+| odf       | ceph CLI + generic                                 |
+| portworx  | pxctl + generic                                    |
+
+## Phase state machine
+
+```
+Pending → Deploying → Ready → Running ⇄ Sleeping → Collecting → Completed
+                                  ↓                                  ↓
+                                Failed                           Degraded
+```
+
+## Benchmark-specific primary metrics
+
+| Benchmark | Primary metric       | Storage metrics (all benchmarks)     |
+|-----------|----------------------|--------------------------------------|
+| HammerDB  | nopm, tpm            | avgReadIops, avgWriteIops,           |
+| pgbench   | tps                  | avgReadBwMBs, avgWriteBwMBs,         |
+| sysbench  | tps, qps             | avgLatencyMs, p95LatencyMs,          |
+| YCSB      | throughputOpsPerSec  | p99LatencyMs                         |
+
+## Future / reserved fields
+
+- `spec.database.partitionedTables` (pgbench) — PostgreSQL partitioned table support via CNPG
+- `spec.database.partitionMethod` (pgbench) — range | hash
+- Prometheus/Grafana observability integration (Phase 2)
+- Full storage plugin implementations beyond `generic`

--- a/operator/crds/base/common-types.yaml
+++ b/operator/crds/base/common-types.yaml
@@ -1,0 +1,57 @@
+# sherlock-common-types.yaml
+# Shared type definitions referenced by all benchmark Suite CRDs.
+# These are not standalone CRDs — they are inline'd or $ref'd into each benchmark CRD.
+# Kept here for documentation and as the source of truth for schema design.
+
+# ─────────────────────────────────────────────
+# DatabaseSpec — how to deploy the database pods
+# ─────────────────────────────────────────────
+# type: DatabaseSpec
+# fields:
+#   type:               postgresql | mysql | mssql | mongodb
+#   instancesPerNode:   int, 1–8
+#   storageClass:       string (empty = cluster default)
+#   storageSize:        string, e.g. "50Gi"
+#   storagePlugin:      generic | lightbits | odf | portworx
+#   partitionedTables:  bool (postgresql/pgbench only, ignored otherwise)
+#   resources:
+#     requests/limits for cpu and memory
+#   nodeSelector:       map[string]string (optional, for pinning to specific nodes)
+#   tolerations:        []Toleration (standard k8s tolerations)
+
+# ─────────────────────────────────────────────
+# ExecutionSpec — how the Suite runs iterations
+# ─────────────────────────────────────────────
+# type: ExecutionSpec
+# fields:
+#   order:              sequential | parallel
+#   sleepBetweenRuns:   int (seconds, default 30, only meaningful for sequential)
+#   failurePolicy:      abortAll | retryN | continueAndReport
+#   retryLimit:         int (only meaningful when failurePolicy=retryN, default 3)
+#   timeoutPerRun:      string, e.g. "30m" (default "1h")
+
+# ─────────────────────────────────────────────
+# ArtifactSpec — where to store run output
+# ─────────────────────────────────────────────
+# type: ArtifactSpec
+# fields:
+#   collectStats:       bool (default true)
+#   compression:        gzip | zstd | none (default gzip)
+#   destination:
+#     type:             pvc | s3 | local
+#     pvc:
+#       storageClass:   string (empty = cluster default)
+#       size:           string, e.g. "20Gi"
+#       accessMode:     ReadWriteOnce | ReadWriteMany (default ReadWriteOnce)
+#     s3:
+#       endpoint:       string (URL)
+#       bucket:         string
+#       prefix:         string (templated: {{.SuiteName}}, {{.RunName}}, {{.Timestamp}})
+#       credentialsSecret: string (name of k8s Secret with access-key / secret-key)
+#       checksumVerification: bool (default true)
+#     local:
+#       ttlHours:       int (how long collector pod stays alive after run, default 24)
+#   retention:
+#     keepLastN:        int (optional, keep only N most recent bundles)
+#     ttlDays:          int (optional, delete bundles older than N days)
+#     deleteWithSuite:  bool (default false — PVC/bundles survive Suite CR deletion)

--- a/operator/crds/benchmarks/fio-suite.yaml
+++ b/operator/crds/benchmarks/fio-suite.yaml
@@ -1,0 +1,569 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sherlockfiosuites.sherlock.io
+  annotations:
+    sherlock.io/description: "Parameter-sweep suite for fio (storage I/O benchmark, any volume type)"
+spec:
+  group: sherlock.io
+  scope: Namespaced
+  names:
+    plural: sherlockfiosuites
+    singular: sherlockfiosuite
+    kind: SherlockFioSuite
+    shortNames:
+      - slfio
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runs
+          type: string
+          jsonPath: .status.summary.runsCompleted
+        - name: Failed
+          type: string
+          jsonPath: .status.summary.runsFailed
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+
+            spec:
+              type: object
+              required: [storage, execution, sweep, artifacts]
+              properties:
+
+                # ── storage ─────────────────────────────────────────────────
+                # fio is a pure storage benchmark — there is no database layer.
+                # The storage section replaces the database section used by the
+                # DB benchmark CRDs. It describes the PVCs fio will exercise.
+                storage:
+                  type: object
+                  required: [storageSize, volumeMode]
+                  properties:
+                    storageClass:
+                      type: string
+                      default: ""
+                      description: >
+                        StorageClass for fio PVCs. Empty = cluster default.
+                        Any block or filesystem StorageClass works. For raw
+                        block testing set volumeMode=Block and ensure your
+                        StorageClass supports volumeBindingMode: WaitForFirstConsumer.
+                    storageSize:
+                      type: string
+                      pattern: '^[0-9]+[KMGT]i$'
+                      description: >
+                        PVC size per fio worker. Should be larger than workSize
+                        to avoid fio running out of space. E.g. if workSize=100Gi
+                        use at least 110Gi here.
+                    storagePlugin:
+                      type: string
+                      enum: [generic, lightbits, odf, portworx]
+                      default: generic
+                      description: >
+                        Controls storage-side metric collection. 'generic' uses
+                        iostat/vmstat on the nodes where fio pods run. Other values
+                        activate plugin-specific collection alongside generic stats.
+                    volumeMode:
+                      type: string
+                      enum: [Filesystem, Block]
+                      default: Filesystem
+                      description: >
+                        Filesystem: fio uses --directory, PVC mounted as a directory.
+                          Use for NFS, CephFS, or any file-based storage class.
+                        Block: fio uses --filename pointing to the raw block device.
+                          Use for block storage (iSCSI, NVMe-oF, Ceph RBD, etc.)
+                          Requires the StorageClass to support volumeMode: Block.
+                          Maps to VOLUME_MODE=RAW in the original sherlock scripts.
+                    fioPerWorker:
+                      type: integer
+                      minimum: 1
+                      maximum: 16
+                      default: 1
+                      description: >
+                        Number of fio jobs (and PVCs) per worker node. Each job
+                        gets its own PVC. Total PVCs = fioPerWorker × workerCount.
+                        Maps to FIO_PER_WORKER in the original scripts.
+                    workerCount:
+                      type: integer
+                      minimum: 1
+                      description: >
+                        Number of worker nodes to run fio on. The operator selects
+                        nodes using nodeSelector (if set) or all schedulable workers.
+                        Maps to NUMBER_OF_WORKERS in the original scripts.
+                    nodeSelector:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: >
+                        Optional label selector to constrain which nodes receive
+                        fio pods. If omitted, all schedulable worker nodes are used.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: [Exists, Equal]
+                          value:
+                            type: string
+                          effect:
+                            type: string
+                            enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                    resources:
+                      type: object
+                      description: "CPU/memory for each fio pod"
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "1"
+                            memory:
+                              type: string
+                              default: "1Gi"
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "4"
+                            memory:
+                              type: string
+                              default: "2Gi"
+
+                # ── execution ───────────────────────────────────────────────
+                execution:
+                  type: object
+                  properties:
+                    order:
+                      type: string
+                      enum: [sequential, parallel]
+                      default: sequential
+                      description: >
+                        sequential: one parameter combination at a time. Recommended
+                          for storage benchmarking to avoid interference between runs.
+                        parallel: all combinations run simultaneously. Only useful
+                          when you intentionally want to measure contention.
+                    sleepBetweenRuns:
+                      type: integer
+                      minimum: 0
+                      default: 60
+                      description: >
+                        Seconds to wait between runs when order=sequential.
+                        fio benefits from a longer sleep than DB benchmarks to allow
+                        storage caches to drain. Default 60s (vs 30s for DB suites).
+                    failurePolicy:
+                      type: string
+                      enum: [abortAll, retryN, continueAndReport]
+                      default: abortAll
+                    retryLimit:
+                      type: integer
+                      minimum: 1
+                      maximum: 10
+                      default: 3
+                    timeoutPerRun:
+                      type: string
+                      pattern: '^[0-9]+(m|h)$'
+                      default: "2h"
+                      description: >
+                        Maximum wall-clock time per run. Should be significantly longer
+                        than runtime × jobs to account for PVC provisioning time and
+                        fio warmup. Default 2h.
+
+                # ── sweep ───────────────────────────────────────────────────
+                sweep:
+                  type: object
+                  required: [blockSize, rwMixWrite, ioPattern, runtime, jobs, ioDepth, workSize]
+                  description: >
+                    fio-specific sweep axes. Every field accepts a list of values;
+                    the operator expands the cartesian product into individual runs.
+
+                    Direct mapping to fio CLI flags and original sherlock script params:
+                      blockSize   → fio --bs          (BLOCK_SIZE in original)
+                      rwMixWrite  → fio --rwmixwrite   (RWMIXWRITE in original)
+                      ioPattern   → fio --readwrite    (IO_PATTERN in original)
+                      runtime     → fio --runtime      (RUNTIME in original)
+                      jobs        → fio --numjobs      (JOBS in original)
+                      ioDepth     → fio --iodepth      (IODEPTH in original)
+                      workSize    → fio --filesize      (WORKSIZE in original)
+                      directIO    → fio --direct        (DIRECT_IO in original)
+
+                    The original run_fio_tests script swept blockSize across
+                    [4k, 8k, 64k, 128k, 1m] with a fixed rwMixWrite=0 (read-only).
+                    This CRD makes all of those axes explicit and sweepable.
+                  properties:
+                    blockSize:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                        pattern: '^[0-9]+(k|m|g|K|M|G)$'
+                      description: >
+                        fio --bs: I/O block size. Sweep this axis to characterize
+                        storage performance across different transfer sizes.
+                        Common values: 4k (IOPS-bound), 128k/1m (bandwidth-bound).
+                      example: ["4k", "8k", "64k", "128k", "1m"]
+                    rwMixWrite:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 0
+                        maximum: 100
+                      description: >
+                        fio --rwmixwrite: percentage of I/O that is writes (0–100).
+                        0 = read-only, 100 = write-only, 30 = 70% read / 30% write.
+                        Only meaningful when ioPattern includes both reads and writes
+                        (readwrite or randrw). Ignored for read-only/write-only patterns.
+                      example: [0, 30, 50, 100]
+                    ioPattern:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                        enum:
+                          - read          # sequential read
+                          - write         # sequential write
+                          - readwrite     # sequential mixed read/write
+                          - randread      # random read
+                          - randwrite     # random write
+                          - randrw        # random mixed read/write
+                          - trimwrite     # sequential trim+write (for SSDs/NVMe)
+                      description: >
+                        fio --readwrite: I/O access pattern.
+                        Maps to IO_PATTERN in the original scripts.
+                        Use randrw for OLTP-like workloads, read/write for
+                        sequential throughput (backup/restore, streaming).
+                      example: ["randrw", "read", "write"]
+                    runtime:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 10
+                      description: >
+                        fio --runtime: test duration in seconds. fio uses
+                        --time_based so it runs exactly this long regardless of
+                        how much data is written.
+                      example: [60, 120]
+                    jobs:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 256
+                      description: >
+                        fio --numjobs: number of parallel fio threads per pod.
+                        Each thread gets its own file/device slice. Total I/O
+                        concurrency per node = jobs × fioPerWorker.
+                      example: [4]
+                    ioDepth:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 1024
+                      description: >
+                        fio --iodepth: number of I/Os to keep in flight per job.
+                        Critical for NVMe and high-performance block storage where
+                        latency hides behind queue depth. Sweep this to find the
+                        saturation point of your storage.
+                      example: [4]
+                    workSize:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                        pattern: '^[0-9]+(k|m|g|t|K|M|G|T)i?$'
+                      description: >
+                        fio --filesize: size of the test file/device per job.
+                        Should be large enough to exceed storage cache capacity.
+                        For production characterization use at least 2× available
+                        DRAM on the storage nodes.
+                      example: ["2048g"]
+                    directIO:
+                      type: array
+                      items:
+                        type: integer
+                        enum: [0, 1]
+                      default: [1]
+                      description: >
+                        fio --direct: bypass OS page cache (1=direct, 0=buffered).
+                        Always use 1 for storage benchmarking — buffered I/O measures
+                        the OS cache, not the storage. Use 0 only to measure caching
+                        behaviour intentionally.
+                        Maps to DIRECT_IO in the original scripts.
+                    groupReporting:
+                      type: boolean
+                      default: true
+                      description: >
+                        fio --group_reporting: aggregate stats across all jobs in a
+                        single report rather than per-job output. Matches the original
+                        sherlock fio container behaviour. Not a sweep axis.
+                    outputFormat:
+                      type: string
+                      enum: [normal, json, json+, terse]
+                      default: json
+                      description: >
+                        fio --output-format: output format for fio results.
+                        json enables the Python stat parser to extract structured
+                        metrics. normal is human-readable but harder to parse.
+                        The original scripts used 'normal'; v2 defaults to 'json'
+                        for better operator integration. Not a sweep axis.
+
+                # ── artifacts ───────────────────────────────────────────────
+                artifacts:
+                  type: object
+                  required: [destination]
+                  properties:
+                    collectStats:
+                      type: boolean
+                      default: true
+                      description: >
+                        Whether to run stat collector pods (iostat, vmstat, ip)
+                        alongside fio jobs. For fio specifically this is doubly
+                        useful since fio itself generates I/O that the stat
+                        collectors can observe at the OS level in parallel.
+                    compression:
+                      type: string
+                      enum: [gzip, zstd, none]
+                      default: gzip
+                    destination:
+                      type: object
+                      required: [type]
+                      properties:
+                        type:
+                          type: string
+                          enum: [pvc, s3, local]
+                        pvc:
+                          type: object
+                          properties:
+                            storageClass:
+                              type: string
+                              default: ""
+                            size:
+                              type: string
+                              pattern: '^[0-9]+[KMGT]i$'
+                              default: "20Gi"
+                            accessMode:
+                              type: string
+                              enum: [ReadWriteOnce, ReadWriteMany]
+                              default: ReadWriteOnce
+                        s3:
+                          type: object
+                          properties:
+                            endpoint:
+                              type: string
+                            bucket:
+                              type: string
+                            prefix:
+                              type: string
+                              default: "sherlock/{{.SuiteName}}/"
+                            credentialsSecret:
+                              type: string
+                            checksumVerification:
+                              type: boolean
+                              default: true
+                        local:
+                          type: object
+                          properties:
+                            ttlHours:
+                              type: integer
+                              minimum: 1
+                              maximum: 168
+                              default: 24
+                    retention:
+                      type: object
+                      properties:
+                        keepLastN:
+                          type: integer
+                          minimum: 1
+                        ttlDays:
+                          type: integer
+                          minimum: 1
+                        deleteWithSuite:
+                          type: boolean
+                          default: false
+
+            # ── status ────────────────────────────────────────────────────────
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Provisioning, Ready, Running, Sleeping,
+                         Collecting, Completed, Degraded, Failed]
+                  description: >
+                    fio adds a 'Provisioning' phase (between Pending and Ready)
+                    because PVC provisioning for block storage can take significant
+                    time, especially with large storageSize values.
+                observedGeneration:
+                  type: integer
+                runMatrix:
+                  type: array
+                  description: >
+                    Expanded cartesian product of sweep axes. Each entry is one fio run.
+                    Run names encode the swept parameters, e.g.:
+                    "nvme-sweep-bs4k-rw0-randrw-rt60-j4-qd4-2048g"
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      params:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      phase:
+                        type: string
+                        enum: [Pending, Running, Completed, Failed, Retrying]
+                      startTime:
+                        type: string
+                        format: date-time
+                      completionTime:
+                        type: string
+                        format: date-time
+                      retryCount:
+                        type: integer
+                        default: 0
+                      artifactPath:
+                        type: string
+                      result:
+                        type: object
+                        description: >
+                          Parsed from fio JSON output (--output-format=json).
+                          All IOPS and bandwidth values are aggregates across all
+                          jobs and all workers (group_reporting=true).
+                        properties:
+                          # Read metrics
+                          readIops:
+                            type: number
+                            description: "Aggregate read IOPS across all jobs/workers"
+                          readBwMBs:
+                            type: number
+                            description: "Aggregate read bandwidth in MB/s"
+                          readLatAvgUs:
+                            type: number
+                            description: "Average read completion latency in microseconds"
+                          readLatP50Us:
+                            type: number
+                          readLatP95Us:
+                            type: number
+                          readLatP99Us:
+                            type: number
+                          readLatP999Us:
+                            type: number
+                            description: "p99.9 — important for NVMe-oF tail latency"
+                          # Write metrics
+                          writeIops:
+                            type: number
+                            description: "Aggregate write IOPS across all jobs/workers"
+                          writeBwMBs:
+                            type: number
+                          writeLatAvgUs:
+                            type: number
+                          writeLatP50Us:
+                            type: number
+                          writeLatP95Us:
+                            type: number
+                          writeLatP99Us:
+                            type: number
+                          writeLatP999Us:
+                            type: number
+                          # Combined / derived
+                          totalIops:
+                            type: number
+                            description: "readIops + writeIops"
+                          totalBwMBs:
+                            type: number
+                            description: "readBwMBs + writeBwMBs"
+                          # OS-level metrics from stat collectors
+                          # (same fields as DB benchmarks for cross-suite comparison)
+                          avgReadIops:
+                            type: number
+                            description: "iostat read IOPS from stat collector pods"
+                          avgWriteIops:
+                            type: number
+                          avgReadBwMBs:
+                            type: number
+                          avgWriteBwMBs:
+                            type: number
+                          avgLatencyMs:
+                            type: number
+                          p95LatencyMs:
+                            type: number
+                          p99LatencyMs:
+                            type: number
+                summary:
+                  type: object
+                  properties:
+                    totalRuns:
+                      type: integer
+                    runsCompleted:
+                      type: integer
+                    runsFailed:
+                      type: integer
+                    runsRemaining:
+                      type: integer
+                    currentRunName:
+                      type: string
+                    totalPvcsProvisioned:
+                      type: integer
+                      description: "fio-specific: tracks PVC count across all workers"
+                artifacts:
+                  type: object
+                  properties:
+                    pvcName:
+                      type: string
+                    bundles:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          runName:
+                            type: string
+                          path:
+                            type: string
+                          sizeBytes:
+                            type: integer
+                          collectedAt:
+                            type: string
+                            format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime]
+                    properties:
+                      type:
+                        type: string
+                        enum: [PVCsReady, SweepRunning, ArtifactsAvailable, Failed]
+                        description: >
+                          fio uses 'PVCsReady' instead of 'DatabaseReady' since
+                          there is no database layer to wait for.
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/operator/crds/benchmarks/hammerdb-suite.yaml
+++ b/operator/crds/benchmarks/hammerdb-suite.yaml
@@ -1,0 +1,504 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sherlockhammerdbsuites.sherlock.io
+  annotations:
+    sherlock.io/description: "Parameter-sweep suite for HammerDB (MSSQL/MySQL)"
+spec:
+  group: sherlock.io
+  scope: Namespaced
+  names:
+    plural: sherlockhammerdbsuites
+    singular: sherlockhammerdbsuite
+    kind: SherlockHammerDBSuite
+    shortNames:
+      - slhdb
+      - slhammerdb
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runs
+          type: string
+          jsonPath: .status.summary.runsCompleted
+        - name: Failed
+          type: string
+          jsonPath: .status.summary.runsFailed
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+
+            # ── spec ──────────────────────────────────────────────────────────
+            spec:
+              type: object
+              required: [database, execution, sweep, artifacts]
+              properties:
+
+                # ── database ────────────────────────────────────────────────
+                database:
+                  type: object
+                  required: [type, instancesPerNode, storageSize]
+                  properties:
+                    type:
+                      type: string
+                      enum: [mssql, mysql]
+                      description: >
+                        Database engine. HammerDB supports MSSQL (TPC-C) and MySQL (TPC-C).
+                    instancesPerNode:
+                      type: integer
+                      minimum: 1
+                      maximum: 8
+                      default: 1
+                      description: >
+                        Number of database pods per worker node. The operator spreads
+                        pods evenly using pod anti-affinity so no two pods of the same
+                        index land on the same node.
+                    storageClass:
+                      type: string
+                      default: ""
+                      description: >
+                        StorageClass for database PVCs. Empty string uses the cluster
+                        default. Any block or file storageClass works.
+                    storageSize:
+                      type: string
+                      pattern: '^[0-9]+[KMGT]i$'
+                      description: "PVC size per database instance, e.g. 100Gi"
+                    storagePlugin:
+                      type: string
+                      enum: [generic, lightbits, odf, portworx]
+                      default: generic
+                      description: >
+                        Controls which storage-side metric collection logic is used.
+                        'generic' collects iostat/vmstat from the nodes where DB pods
+                        run, with no storage-array knowledge. Other values activate
+                        plugin-specific collection (e.g. lbcli for lightbits).
+                    resources:
+                      type: object
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "2"
+                            memory:
+                              type: string
+                              default: "4Gi"
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "4"
+                            memory:
+                              type: string
+                              default: "8Gi"
+                    nodeSelector:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: >
+                        Optional label selector to constrain which nodes receive
+                        database pods. If omitted, all schedulable nodes are candidates.
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: [Exists, Equal]
+                          value:
+                            type: string
+                          effect:
+                            type: string
+                            enum: [NoSchedule, PreferNoSchedule, NoExecute]
+                          tolerationSeconds:
+                            type: integer
+
+                # ── execution ───────────────────────────────────────────────
+                execution:
+                  type: object
+                  properties:
+                    order:
+                      type: string
+                      enum: [sequential, parallel]
+                      default: sequential
+                      description: >
+                        Whether sweep iterations run one at a time (sequential, matches
+                        the original shell script behaviour) or all at once (parallel).
+                        Parallel is faster but requires more cluster resources and makes
+                        storage contention harder to reason about.
+                    sleepBetweenRuns:
+                      type: integer
+                      minimum: 0
+                      default: 30
+                      description: >
+                        Seconds to wait between runs when order=sequential. Matches the
+                        SLEEP variable in the original sherlock shell scripts.
+                    failurePolicy:
+                      type: string
+                      enum: [abortAll, retryN, continueAndReport]
+                      default: abortAll
+                      description: >
+                        abortAll: cancel all remaining runs if any run fails.
+                        retryN: retry the failed run up to retryLimit times before
+                          considering it failed.
+                        continueAndReport: let remaining runs proceed, mark the suite
+                          Degraded at completion.
+                    retryLimit:
+                      type: integer
+                      minimum: 1
+                      maximum: 10
+                      default: 3
+                      description: >
+                        Maximum retry attempts per run. Only used when
+                        failurePolicy=retryN.
+                    timeoutPerRun:
+                      type: string
+                      pattern: '^[0-9]+(m|h)$'
+                      default: "1h"
+                      description: >
+                        Maximum wall-clock time allowed for a single run before it is
+                        considered failed. Format: 30m, 2h, etc.
+
+                # ── sweep ───────────────────────────────────────────────────
+                sweep:
+                  type: object
+                  description: >
+                    Parameter sweep axes for HammerDB. Every field accepts a list of
+                    values. The operator takes the cartesian product of all multi-value
+                    fields to generate the run matrix. Single-value fields are fixed
+                    parameters that do not expand.
+                    Example: virtualUsers=[8,16] × testMins=[5,10] → 4 runs.
+                  required: [virtualUsers, warehouses, rampupMins, testMins]
+                  properties:
+                    virtualUsers:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 2048
+                      description: >
+                        HammerDB virtual user counts to sweep. Maps to 'vusers' in
+                        HammerDB TCL config. This is the primary scaling axis for
+                        TPC-C throughput tests.
+                      example: [8, 16, 32]
+                    warehouses:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                      description: >
+                        TPC-C warehouse count. Controls dataset size. Each warehouse
+                        is approximately 100MB. For a sweep that holds dataset size
+                        constant, use a single value: [100].
+                      example: [100]
+                    rampupMins:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 0
+                      description: >
+                        Warmup duration in minutes before measurement begins.
+                        Maps to 'rampup' in HammerDB TCL config.
+                      example: [2]
+                    testMins:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                      description: >
+                        Measurement window duration in minutes.
+                        Maps to 'duration' in HammerDB TCL config.
+                      example: [5, 10]
+                    allWarehouses:
+                      type: array
+                      items:
+                        type: boolean
+                      default: [false]
+                      description: >
+                        When true, virtual users operate across all warehouses rather
+                        than being pinned to a subset. Maps to 'allwarehouse' in
+                        HammerDB TCL config.
+
+                # ── artifacts ───────────────────────────────────────────────
+                artifacts:
+                  type: object
+                  required: [destination]
+                  properties:
+                    collectStats:
+                      type: boolean
+                      default: true
+                      description: >
+                        Whether to run stat collector pods (iostat, vmstat, ip/ifconfig)
+                        alongside benchmark jobs. Set false to run benchmark-only with
+                        no OS-level collection.
+                    compression:
+                      type: string
+                      enum: [gzip, zstd, none]
+                      default: gzip
+                      description: >
+                        Compression algorithm for artifact bundles. zstd is faster and
+                        compresses better; gzip is more universally available.
+                    destination:
+                      type: object
+                      required: [type]
+                      properties:
+                        type:
+                          type: string
+                          enum: [pvc, s3, local]
+                          description: >
+                            pvc: operator creates a PVC and writes bundles there.
+                              Survives pod restarts. Best for in-cluster access.
+                            s3: bundles streamed directly to S3-compatible object
+                              storage. No PVC required. Best for external archiving.
+                            local: bundles held in emptyDir on a collector pod.
+                              User retrieves with 'kubectl sherlock pull'. Best for
+                              laptop/workstation access.
+                        pvc:
+                          type: object
+                          description: "Required when type=pvc"
+                          properties:
+                            storageClass:
+                              type: string
+                              default: ""
+                              description: >
+                                StorageClass for the artifacts PVC. Does not need to
+                                match the database storageClass — any file or block
+                                class works. Empty = cluster default.
+                            size:
+                              type: string
+                              pattern: '^[0-9]+[KMGT]i$'
+                              default: "20Gi"
+                            accessMode:
+                              type: string
+                              enum: [ReadWriteOnce, ReadWriteMany]
+                              default: ReadWriteOnce
+                              description: >
+                                Use ReadWriteMany if you want to access the PVC from
+                                multiple pods simultaneously (e.g. for a results viewer).
+                        s3:
+                          type: object
+                          description: "Required when type=s3"
+                          properties:
+                            endpoint:
+                              type: string
+                              description: >
+                                S3-compatible endpoint URL. For AWS S3 use the regional
+                                endpoint, e.g. https://s3.us-east-1.amazonaws.com.
+                                For MinIO or Lightbits object storage use the internal
+                                service URL.
+                            bucket:
+                              type: string
+                            prefix:
+                              type: string
+                              default: "sherlock/{{.SuiteName}}/"
+                              description: >
+                                Path prefix within the bucket. Supports Go template
+                                variables: {{.SuiteName}}, {{.RunName}}, {{.Timestamp}}.
+                            credentialsSecret:
+                              type: string
+                              description: >
+                                Name of a k8s Secret in the same namespace containing
+                                keys 'access-key' and 'secret-key'.
+                            checksumVerification:
+                              type: boolean
+                              default: true
+                        local:
+                          type: object
+                          description: "Optional config when type=local"
+                          properties:
+                            ttlHours:
+                              type: integer
+                              minimum: 1
+                              maximum: 168
+                              default: 24
+                              description: >
+                                How many hours the collector pod (and its emptyDir)
+                                stays alive after the suite completes, waiting for
+                                the user to pull artifacts. After TTL the pod is
+                                deleted and artifacts are lost.
+                      # cross-field validation: type=pvc requires pvc block, etc.
+                      # enforced by a validating webhook (not expressible in OpenAPI v3)
+                    retention:
+                      type: object
+                      description: >
+                        Controls how long artifact bundles are kept. Only applies to
+                        pvc and s3 destinations; local is controlled by ttlHours.
+                      properties:
+                        keepLastN:
+                          type: integer
+                          minimum: 1
+                          description: >
+                            Keep only the N most recent bundles. When a new suite run
+                            adds a bundle that pushes the count over N, the oldest is
+                            deleted. Mutually exclusive with ttlDays (use one or both;
+                            whichever triggers first wins).
+                        ttlDays:
+                          type: integer
+                          minimum: 1
+                          description: >
+                            Delete bundles older than N days. The operator runs a
+                            cleanup reconcile daily.
+                        deleteWithSuite:
+                          type: boolean
+                          default: false
+                          description: >
+                            If true, deleting the SherlockHammerDBSuite CR also deletes
+                            the artifact PVC or S3 objects. Default false to prevent
+                            accidental data loss.
+
+            # ── status ────────────────────────────────────────────────────────
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending       # CR created, operator hasn't started yet
+                    - Deploying     # DB pods being created
+                    - Ready         # DB pods running, waiting for first run
+                    - Running       # a run is currently active
+                    - Sleeping      # between runs (sequential mode, sleepBetweenRuns)
+                    - Collecting    # run finished, collecting artifacts
+                    - Completed     # all runs done, all artifacts collected
+                    - Degraded      # completed with some failures (continueAndReport)
+                    - Failed        # aborted due to failure
+                observedGeneration:
+                  type: integer
+                  description: Generation of the spec this status reflects.
+                runMatrix:
+                  type: array
+                  description: >
+                    Expanded cartesian product of sweep axes. Populated by the operator
+                    when it first processes the Suite. Each entry is one SherlockRun.
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: >
+                          Auto-generated name encoding the parameter values,
+                          e.g. "mssql-vu-sweep-vu16-wh100-rm2-tm5"
+                      params:
+                        type: object
+                        description: Resolved parameter values for this run.
+                        x-kubernetes-preserve-unknown-fields: true
+                      phase:
+                        type: string
+                        enum: [Pending, Running, Completed, Failed, Retrying]
+                      startTime:
+                        type: string
+                        format: date-time
+                      completionTime:
+                        type: string
+                        format: date-time
+                      retryCount:
+                        type: integer
+                        default: 0
+                      artifactPath:
+                        type: string
+                        description: >
+                          Path or S3 key where this run's bundle was written.
+                      result:
+                        type: object
+                        description: Parsed summary written by the Python stat parser.
+                        properties:
+                          nopm:
+                            type: number
+                            description: New Orders Per Minute (HammerDB primary metric)
+                          tpm:
+                            type: number
+                            description: Transactions Per Minute
+                          avgReadIops:
+                            type: number
+                          avgWriteIops:
+                            type: number
+                          avgReadBwMBs:
+                            type: number
+                          avgWriteBwMBs:
+                            type: number
+                          avgLatencyMs:
+                            type: number
+                          p95LatencyMs:
+                            type: number
+                          p99LatencyMs:
+                            type: number
+                summary:
+                  type: object
+                  description: Aggregate across all completed runs.
+                  properties:
+                    totalRuns:
+                      type: integer
+                    runsCompleted:
+                      type: integer
+                    runsFailed:
+                      type: integer
+                    runsRemaining:
+                      type: integer
+                    currentRunName:
+                      type: string
+                    estimatedCompletionTime:
+                      type: string
+                      format: date-time
+                artifacts:
+                  type: object
+                  properties:
+                    pvcName:
+                      type: string
+                    bundles:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          runName:
+                            type: string
+                          path:
+                            type: string
+                          sizeBytes:
+                            type: integer
+                          collectedAt:
+                            type: string
+                            format: date-time
+                conditions:
+                  type: array
+                  description: Standard k8s condition list for controller-manager compatibility.
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime]
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - DatabaseReady
+                          - SweepRunning
+                          - ArtifactsAvailable
+                          - Failed
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/operator/crds/benchmarks/pgbench-suite.yaml
+++ b/operator/crds/benchmarks/pgbench-suite.yaml
@@ -1,0 +1,412 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sherlockpgbenchsuites.sherlock.io
+  annotations:
+    sherlock.io/description: "Parameter-sweep suite for pgbench (PostgreSQL)"
+spec:
+  group: sherlock.io
+  scope: Namespaced
+  names:
+    plural: sherlockpgbenchsuites
+    singular: sherlockpgbenchsuite
+    kind: SherlockPgbenchSuite
+    shortNames:
+      - slpg
+      - slpgbench
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runs
+          type: string
+          jsonPath: .status.summary.runsCompleted
+        - name: Failed
+          type: string
+          jsonPath: .status.summary.runsFailed
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [database, execution, sweep, artifacts]
+              properties:
+
+                # ── database ────────────────────────────────────────────────
+                # Identical structure to HammerDB except:
+                #  - type is fixed to postgresql
+                #  - adds partitionedTables field
+                database:
+                  type: object
+                  required: [instancesPerNode, storageSize]
+                  properties:
+                    type:
+                      type: string
+                      enum: [postgresql]
+                      default: postgresql
+                    instancesPerNode:
+                      type: integer
+                      minimum: 1
+                      maximum: 8
+                      default: 1
+                    storageClass:
+                      type: string
+                      default: ""
+                    storageSize:
+                      type: string
+                      pattern: '^[0-9]+[KMGT]i$'
+                    storagePlugin:
+                      type: string
+                      enum: [generic, lightbits, odf, portworx]
+                      default: generic
+                    partitionedTables:
+                      type: boolean
+                      default: false
+                      description: >
+                        When true, the operator initializes pgbench with --partitions=N
+                        where N is derived from instancesPerNode. Requires PostgreSQL
+                        >= 10. CNPG clusters handle the pg_partman setup automatically
+                        when using the CNPG database operator; for vanilla PostgreSQL
+                        the operator runs the DDL via a Job before the prepare phase.
+                        This is a future capability — field is reserved, not yet
+                        implemented. Setting true on v1alpha1 has no effect.
+                    partitionMethod:
+                      type: string
+                      enum: [range, hash]
+                      default: range
+                      description: >
+                        Partition strategy when partitionedTables=true.
+                        Maps to pgbench --partition-method flag.
+                        Only meaningful when partitionedTables=true.
+                    resources:
+                      type: object
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "2"
+                            memory:
+                              type: string
+                              default: "4Gi"
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "4"
+                            memory:
+                              type: string
+                              default: "8Gi"
+                    nodeSelector:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: [Exists, Equal]
+                          value:
+                            type: string
+                          effect:
+                            type: string
+                            enum: [NoSchedule, PreferNoSchedule, NoExecute]
+
+                # ── execution ───────────────────────────────────────────────
+                # Identical to HammerDB
+                execution:
+                  type: object
+                  properties:
+                    order:
+                      type: string
+                      enum: [sequential, parallel]
+                      default: sequential
+                    sleepBetweenRuns:
+                      type: integer
+                      minimum: 0
+                      default: 30
+                    failurePolicy:
+                      type: string
+                      enum: [abortAll, retryN, continueAndReport]
+                      default: abortAll
+                    retryLimit:
+                      type: integer
+                      minimum: 1
+                      maximum: 10
+                      default: 3
+                    timeoutPerRun:
+                      type: string
+                      pattern: '^[0-9]+(m|h)$'
+                      default: "1h"
+
+                # ── sweep ───────────────────────────────────────────────────
+                sweep:
+                  type: object
+                  required: [clients, scaleFactor, duration]
+                  description: >
+                    pgbench-specific sweep axes. The operator maps these to pgbench
+                    CLI flags: clients→-c, threads→-j, scaleFactor→-s, duration→-T.
+                    readWriteRatio controls which built-in script is used:
+                      100 = read-only  (pgbench -S)
+                        0 = write-only (pgbench --no-vacuum with write script)
+                       other = mixed, operator generates a custom script weighting
+                               SELECT vs UPDATE/INSERT accordingly.
+                  properties:
+                    clients:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 1024
+                      description: "pgbench -c: number of concurrent clients (primary sweep axis)"
+                      example: [1, 2, 8, 16]
+                    threads:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                      default: [4]
+                      description: "pgbench -j: number of worker threads"
+                    readWriteRatio:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 0
+                        maximum: 100
+                      default: [100]
+                      description: >
+                        Percentage of operations that are reads (0–100).
+                        100 = read-only, 0 = write-only, 70 = 70% read / 30% write.
+                      example: [100, 70, 50]
+                    scaleFactor:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                      description: >
+                        pgbench -s: scale factor. Each unit ≈ 16MB of data (100k rows).
+                        scaleFactor=100 → ~1.6GB database.
+                      example: [100]
+                    duration:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 10
+                      description: "pgbench -T: test duration in seconds"
+                      example: [120]
+                    protocol:
+                      type: array
+                      items:
+                        type: string
+                        enum: [simple, extended, prepared]
+                      default: [simple]
+                      description: >
+                        pgbench --protocol: query protocol.
+                        prepared is most representative of real application behaviour.
+
+                # ── artifacts ───────────────────────────────────────────────
+                # Identical structure to HammerDB — omitted here for brevity,
+                # the operator uses the same schema for all benchmark Suite kinds.
+                artifacts:
+                  type: object
+                  required: [destination]
+                  properties:
+                    collectStats:
+                      type: boolean
+                      default: true
+                    compression:
+                      type: string
+                      enum: [gzip, zstd, none]
+                      default: gzip
+                    destination:
+                      type: object
+                      required: [type]
+                      properties:
+                        type:
+                          type: string
+                          enum: [pvc, s3, local]
+                        pvc:
+                          type: object
+                          properties:
+                            storageClass:
+                              type: string
+                              default: ""
+                            size:
+                              type: string
+                              pattern: '^[0-9]+[KMGT]i$'
+                              default: "20Gi"
+                            accessMode:
+                              type: string
+                              enum: [ReadWriteOnce, ReadWriteMany]
+                              default: ReadWriteOnce
+                        s3:
+                          type: object
+                          properties:
+                            endpoint:
+                              type: string
+                            bucket:
+                              type: string
+                            prefix:
+                              type: string
+                              default: "sherlock/{{.SuiteName}}/"
+                            credentialsSecret:
+                              type: string
+                            checksumVerification:
+                              type: boolean
+                              default: true
+                        local:
+                          type: object
+                          properties:
+                            ttlHours:
+                              type: integer
+                              minimum: 1
+                              maximum: 168
+                              default: 24
+                    retention:
+                      type: object
+                      properties:
+                        keepLastN:
+                          type: integer
+                          minimum: 1
+                        ttlDays:
+                          type: integer
+                          minimum: 1
+                        deleteWithSuite:
+                          type: boolean
+                          default: false
+
+            # ── status ────────────────────────────────────────────────────────
+            # Identical structure to HammerDB except result metrics differ:
+            # pgbench reports TPS rather than NOPM/TPM
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Deploying, Ready, Running, Sleeping,
+                         Collecting, Completed, Degraded, Failed]
+                observedGeneration:
+                  type: integer
+                runMatrix:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      params:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      phase:
+                        type: string
+                        enum: [Pending, Running, Completed, Failed, Retrying]
+                      startTime:
+                        type: string
+                        format: date-time
+                      completionTime:
+                        type: string
+                        format: date-time
+                      retryCount:
+                        type: integer
+                        default: 0
+                      artifactPath:
+                        type: string
+                      result:
+                        type: object
+                        properties:
+                          tps:
+                            type: number
+                            description: Transactions per second (pgbench primary metric)
+                          latencyAvgMs:
+                            type: number
+                            description: Average transaction latency (pgbench output)
+                          latencyStddevMs:
+                            type: number
+                          avgReadIops:
+                            type: number
+                          avgWriteIops:
+                            type: number
+                          avgReadBwMBs:
+                            type: number
+                          avgWriteBwMBs:
+                            type: number
+                          avgLatencyMs:
+                            type: number
+                          p95LatencyMs:
+                            type: number
+                          p99LatencyMs:
+                            type: number
+                summary:
+                  type: object
+                  properties:
+                    totalRuns:
+                      type: integer
+                    runsCompleted:
+                      type: integer
+                    runsFailed:
+                      type: integer
+                    runsRemaining:
+                      type: integer
+                    currentRunName:
+                      type: string
+                artifacts:
+                  type: object
+                  properties:
+                    pvcName:
+                      type: string
+                    bundles:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          runName:
+                            type: string
+                          path:
+                            type: string
+                          sizeBytes:
+                            type: integer
+                          collectedAt:
+                            type: string
+                            format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime]
+                    properties:
+                      type:
+                        type: string
+                        enum: [DatabaseReady, SweepRunning, ArtifactsAvailable, Failed]
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/operator/crds/benchmarks/sysbench-suite.yaml
+++ b/operator/crds/benchmarks/sysbench-suite.yaml
@@ -1,0 +1,386 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sherlockpgbenchsuites.sherlock.io
+  annotations:
+    sherlock.io/description: "Parameter-sweep suite for sysbench (MySQL / PostgreSQL)"
+spec:
+  group: sherlock.io
+  scope: Namespaced
+  names:
+    plural: sherlocksysbenchsuites
+    singular: sherlocksysbenchsuite
+    kind: SherlockSysbenchSuite
+    shortNames:
+      - slsys
+      - slsysbench
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runs
+          type: string
+          jsonPath: .status.summary.runsCompleted
+        - name: Failed
+          type: string
+          jsonPath: .status.summary.runsFailed
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [database, execution, sweep, artifacts]
+              properties:
+
+                database:
+                  type: object
+                  required: [type, instancesPerNode, storageSize]
+                  properties:
+                    type:
+                      type: string
+                      enum: [mysql, postgresql]
+                      description: "sysbench supports both MySQL and PostgreSQL"
+                    instancesPerNode:
+                      type: integer
+                      minimum: 1
+                      maximum: 8
+                      default: 1
+                    storageClass:
+                      type: string
+                      default: ""
+                    storageSize:
+                      type: string
+                      pattern: '^[0-9]+[KMGT]i$'
+                    storagePlugin:
+                      type: string
+                      enum: [generic, lightbits, odf, portworx]
+                      default: generic
+                    resources:
+                      type: object
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "2"
+                            memory:
+                              type: string
+                              default: "4Gi"
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "4"
+                            memory:
+                              type: string
+                              default: "8Gi"
+                    nodeSelector:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: [Exists, Equal]
+                          value:
+                            type: string
+                          effect:
+                            type: string
+                            enum: [NoSchedule, PreferNoSchedule, NoExecute]
+
+                execution:
+                  type: object
+                  properties:
+                    order:
+                      type: string
+                      enum: [sequential, parallel]
+                      default: sequential
+                    sleepBetweenRuns:
+                      type: integer
+                      minimum: 0
+                      default: 30
+                    failurePolicy:
+                      type: string
+                      enum: [abortAll, retryN, continueAndReport]
+                      default: abortAll
+                    retryLimit:
+                      type: integer
+                      minimum: 1
+                      maximum: 10
+                      default: 3
+                    timeoutPerRun:
+                      type: string
+                      pattern: '^[0-9]+(m|h)$'
+                      default: "1h"
+
+                sweep:
+                  type: object
+                  required: [threads, tables, tableSize, testType, duration]
+                  description: >
+                    sysbench-specific sweep axes. Maps to sysbench CLI flags:
+                    threads→--threads, tables→--tables, tableSize→--table-size,
+                    duration→--time, testType selects the Lua script
+                    (oltp_read_write, oltp_read_only, oltp_write_only, etc.).
+                  properties:
+                    threads:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 1024
+                      description: "sysbench --threads: concurrent worker threads (primary sweep axis)"
+                      example: [4, 8, 16, 32]
+                    tables:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                      default: [8]
+                      description: "sysbench --tables: number of tables"
+                    tableSize:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1000
+                      description: "sysbench --table-size: rows per table"
+                      example: [1000000]
+                    testType:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                        enum:
+                          - oltp_read_write
+                          - oltp_read_only
+                          - oltp_write_only
+                          - oltp_point_select
+                          - oltp_update_index
+                          - oltp_update_non_index
+                          - oltp_insert
+                          - oltp_delete
+                          - bulk_insert
+                          - select_random_points
+                          - select_random_ranges
+                      default: [oltp_read_write]
+                      description: "sysbench Lua script name to use"
+                    duration:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 10
+                      description: "sysbench --time: test duration in seconds"
+                      example: [120]
+                    reportInterval:
+                      type: integer
+                      minimum: 1
+                      default: 10
+                      description: >
+                        sysbench --report-interval: how often (seconds) sysbench
+                        prints intermediate stats. Not a sweep axis — single value.
+                        Lower values give finer time-series data in the parsed output.
+
+                artifacts:
+                  type: object
+                  required: [destination]
+                  properties:
+                    collectStats:
+                      type: boolean
+                      default: true
+                    compression:
+                      type: string
+                      enum: [gzip, zstd, none]
+                      default: gzip
+                    destination:
+                      type: object
+                      required: [type]
+                      properties:
+                        type:
+                          type: string
+                          enum: [pvc, s3, local]
+                        pvc:
+                          type: object
+                          properties:
+                            storageClass:
+                              type: string
+                              default: ""
+                            size:
+                              type: string
+                              pattern: '^[0-9]+[KMGT]i$'
+                              default: "20Gi"
+                            accessMode:
+                              type: string
+                              enum: [ReadWriteOnce, ReadWriteMany]
+                              default: ReadWriteOnce
+                        s3:
+                          type: object
+                          properties:
+                            endpoint:
+                              type: string
+                            bucket:
+                              type: string
+                            prefix:
+                              type: string
+                              default: "sherlock/{{.SuiteName}}/"
+                            credentialsSecret:
+                              type: string
+                            checksumVerification:
+                              type: boolean
+                              default: true
+                        local:
+                          type: object
+                          properties:
+                            ttlHours:
+                              type: integer
+                              minimum: 1
+                              maximum: 168
+                              default: 24
+                    retention:
+                      type: object
+                      properties:
+                        keepLastN:
+                          type: integer
+                          minimum: 1
+                        ttlDays:
+                          type: integer
+                          minimum: 1
+                        deleteWithSuite:
+                          type: boolean
+                          default: false
+
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Deploying, Ready, Running, Sleeping,
+                         Collecting, Completed, Degraded, Failed]
+                observedGeneration:
+                  type: integer
+                runMatrix:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      params:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      phase:
+                        type: string
+                        enum: [Pending, Running, Completed, Failed, Retrying]
+                      startTime:
+                        type: string
+                        format: date-time
+                      completionTime:
+                        type: string
+                        format: date-time
+                      retryCount:
+                        type: integer
+                        default: 0
+                      artifactPath:
+                        type: string
+                      result:
+                        type: object
+                        properties:
+                          tps:
+                            type: number
+                            description: Transactions per second (sysbench primary metric)
+                          qps:
+                            type: number
+                            description: Queries per second
+                          latencyAvgMs:
+                            type: number
+                          latencyP95Ms:
+                            type: number
+                            description: sysbench reports 95th percentile natively
+                          latencyMaxMs:
+                            type: number
+                          avgReadIops:
+                            type: number
+                          avgWriteIops:
+                            type: number
+                          avgReadBwMBs:
+                            type: number
+                          avgWriteBwMBs:
+                            type: number
+                          avgLatencyMs:
+                            type: number
+                          p95LatencyMs:
+                            type: number
+                          p99LatencyMs:
+                            type: number
+                summary:
+                  type: object
+                  properties:
+                    totalRuns:
+                      type: integer
+                    runsCompleted:
+                      type: integer
+                    runsFailed:
+                      type: integer
+                    runsRemaining:
+                      type: integer
+                    currentRunName:
+                      type: string
+                artifacts:
+                  type: object
+                  properties:
+                    pvcName:
+                      type: string
+                    bundles:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          runName:
+                            type: string
+                          path:
+                            type: string
+                          sizeBytes:
+                            type: integer
+                          collectedAt:
+                            type: string
+                            format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime]
+                    properties:
+                      type:
+                        type: string
+                        enum: [DatabaseReady, SweepRunning, ArtifactsAvailable, Failed]
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/operator/crds/benchmarks/ycsb-suite.yaml
+++ b/operator/crds/benchmarks/ycsb-suite.yaml
@@ -1,0 +1,381 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sherlockycsbbenchsuites.sherlock.io
+  annotations:
+    sherlock.io/description: "Parameter-sweep suite for YCSB (MongoDB)"
+spec:
+  group: sherlock.io
+  scope: Namespaced
+  names:
+    plural: sherlockycsbbenchsuites
+    singular: sherlockycsbbenchsuite
+    kind: SherlockYCSBSuite
+    shortNames:
+      - slycsb
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runs
+          type: string
+          jsonPath: .status.summary.runsCompleted
+        - name: Failed
+          type: string
+          jsonPath: .status.summary.runsFailed
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [database, execution, sweep, artifacts]
+              properties:
+
+                database:
+                  type: object
+                  required: [instancesPerNode, storageSize]
+                  properties:
+                    type:
+                      type: string
+                      enum: [mongodb]
+                      default: mongodb
+                    instancesPerNode:
+                      type: integer
+                      minimum: 1
+                      maximum: 8
+                      default: 1
+                    storageClass:
+                      type: string
+                      default: ""
+                    storageSize:
+                      type: string
+                      pattern: '^[0-9]+[KMGT]i$'
+                    storagePlugin:
+                      type: string
+                      enum: [generic, lightbits, odf, portworx]
+                      default: generic
+                    resources:
+                      type: object
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "2"
+                            memory:
+                              type: string
+                              default: "4Gi"
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              default: "4"
+                            memory:
+                              type: string
+                              default: "8Gi"
+                    nodeSelector:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: [Exists, Equal]
+                          value:
+                            type: string
+                          effect:
+                            type: string
+                            enum: [NoSchedule, PreferNoSchedule, NoExecute]
+
+                execution:
+                  type: object
+                  properties:
+                    order:
+                      type: string
+                      enum: [sequential, parallel]
+                      default: sequential
+                    sleepBetweenRuns:
+                      type: integer
+                      minimum: 0
+                      default: 30
+                    failurePolicy:
+                      type: string
+                      enum: [abortAll, retryN, continueAndReport]
+                      default: abortAll
+                    retryLimit:
+                      type: integer
+                      minimum: 1
+                      maximum: 10
+                      default: 3
+                    timeoutPerRun:
+                      type: string
+                      pattern: '^[0-9]+(m|h)$'
+                      default: "1h"
+
+                sweep:
+                  type: object
+                  required: [threads, workload, recordCount, operationCount]
+                  description: >
+                    YCSB-specific sweep axes.
+                    workload maps to the YCSB built-in workloads:
+                      a: 50% read / 50% update
+                      b: 95% read /  5% update
+                      c: 100% read
+                      d: 95% read /  5% insert (latest distribution)
+                      e: 95% scan  /  5% insert
+                      f: 50% read  / 50% read-modify-write
+                    These are the standard YCSB workload letters used in research.
+                  properties:
+                    threads:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 1024
+                      description: "YCSB -threads: concurrent client threads"
+                      example: [4, 8, 16]
+                    workload:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                        enum: [a, b, c, d, e, f]
+                      description: "YCSB workload letter — defines read/write/scan mix"
+                      example: [a, b, c]
+                    recordCount:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1000
+                      description: "YCSB -p recordcount: number of records in the dataset"
+                      example: [1000000]
+                    operationCount:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                        minimum: 1000
+                      description: "YCSB -p operationcount: number of operations to execute per run"
+                      example: [100000]
+                    requestDistribution:
+                      type: array
+                      items:
+                        type: string
+                        enum: [uniform, zipfian, hotspot, sequential, exponential, latest]
+                      default: [uniform]
+                      description: >
+                        YCSB -p requestdistribution: how keys are selected.
+                        zipfian models real-world skewed access patterns (hot keys).
+                        uniform is the default and most reproducible.
+                    maxExecutionTime:
+                      type: integer
+                      minimum: 10
+                      default: 120
+                      description: >
+                        YCSB -p maxexecutiontime: cap run duration in seconds regardless
+                        of operationCount. Not a sweep axis — single integer.
+
+                artifacts:
+                  type: object
+                  required: [destination]
+                  properties:
+                    collectStats:
+                      type: boolean
+                      default: true
+                    compression:
+                      type: string
+                      enum: [gzip, zstd, none]
+                      default: gzip
+                    destination:
+                      type: object
+                      required: [type]
+                      properties:
+                        type:
+                          type: string
+                          enum: [pvc, s3, local]
+                        pvc:
+                          type: object
+                          properties:
+                            storageClass:
+                              type: string
+                              default: ""
+                            size:
+                              type: string
+                              pattern: '^[0-9]+[KMGT]i$'
+                              default: "20Gi"
+                            accessMode:
+                              type: string
+                              enum: [ReadWriteOnce, ReadWriteMany]
+                              default: ReadWriteOnce
+                        s3:
+                          type: object
+                          properties:
+                            endpoint:
+                              type: string
+                            bucket:
+                              type: string
+                            prefix:
+                              type: string
+                              default: "sherlock/{{.SuiteName}}/"
+                            credentialsSecret:
+                              type: string
+                            checksumVerification:
+                              type: boolean
+                              default: true
+                        local:
+                          type: object
+                          properties:
+                            ttlHours:
+                              type: integer
+                              minimum: 1
+                              maximum: 168
+                              default: 24
+                    retention:
+                      type: object
+                      properties:
+                        keepLastN:
+                          type: integer
+                          minimum: 1
+                        ttlDays:
+                          type: integer
+                          minimum: 1
+                        deleteWithSuite:
+                          type: boolean
+                          default: false
+
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Deploying, Ready, Running, Sleeping,
+                         Collecting, Completed, Degraded, Failed]
+                observedGeneration:
+                  type: integer
+                runMatrix:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      params:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      phase:
+                        type: string
+                        enum: [Pending, Running, Completed, Failed, Retrying]
+                      startTime:
+                        type: string
+                        format: date-time
+                      completionTime:
+                        type: string
+                        format: date-time
+                      retryCount:
+                        type: integer
+                        default: 0
+                      artifactPath:
+                        type: string
+                      result:
+                        type: object
+                        properties:
+                          throughputOpsPerSec:
+                            type: number
+                            description: YCSB primary metric — overall ops/sec
+                          readLatencyAvgUs:
+                            type: number
+                            description: Average read latency in microseconds (YCSB native unit)
+                          readLatencyP95Us:
+                            type: number
+                          readLatencyP99Us:
+                            type: number
+                          updateLatencyAvgUs:
+                            type: number
+                          updateLatencyP95Us:
+                            type: number
+                          avgReadIops:
+                            type: number
+                          avgWriteIops:
+                            type: number
+                          avgReadBwMBs:
+                            type: number
+                          avgWriteBwMBs:
+                            type: number
+                          avgLatencyMs:
+                            type: number
+                          p95LatencyMs:
+                            type: number
+                          p99LatencyMs:
+                            type: number
+                summary:
+                  type: object
+                  properties:
+                    totalRuns:
+                      type: integer
+                    runsCompleted:
+                      type: integer
+                    runsFailed:
+                      type: integer
+                    runsRemaining:
+                      type: integer
+                    currentRunName:
+                      type: string
+                artifacts:
+                  type: object
+                  properties:
+                    pvcName:
+                      type: string
+                    bundles:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          runName:
+                            type: string
+                          path:
+                            type: string
+                          sizeBytes:
+                            type: integer
+                          collectedAt:
+                            type: string
+                            format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime]
+                    properties:
+                      type:
+                        type: string
+                        enum: [DatabaseReady, SweepRunning, ArtifactsAvailable, Failed]
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/operator/crds/examples/fio-example.yaml
+++ b/operator/crds/examples/fio-example.yaml
@@ -1,0 +1,109 @@
+# Example: fio block-size sweep on NVMe-oF block volumes
+# Replicates the original run_fio_tests script pattern:
+#   blockSize swept across [4k, 8k, 64k, 128k, 1m]
+#   with read-only workload (rwMixWrite=0, ioPattern=randread)
+# Plus adds a write-heavy sweep axis: rwMixWrite=[0, 30, 100]
+# Total: 5 × 3 = 15 runs, sequential with 60s sleep between runs
+#
+# Run names will be:
+#   nvme-bs-sweep-bs4k-rw0-randread-rt60-j4-qd4-2048g
+#   nvme-bs-sweep-bs4k-rw30-randrw-rt60-j4-qd4-2048g
+#   ... (15 total)
+---
+apiVersion: sherlock.io/v1alpha1
+kind: SherlockFioSuite
+metadata:
+  name: nvme-bs-sweep
+  namespace: sherlock
+spec:
+  storage:
+    storageClass: lightbits-nvmeof
+    storageSize: 2200Gi          # larger than workSize (2048g) to avoid ENOSPC
+    storagePlugin: lightbits
+    volumeMode: Block            # raw block — NVMe-oF best practice
+    fioPerWorker: 1
+    workerCount: 3
+    nodeSelector:
+      node-role: worker
+    resources:
+      requests: {cpu: "2", memory: "1Gi"}
+      limits:   {cpu: "4", memory: "2Gi"}
+
+  execution:
+    order: sequential
+    sleepBetweenRuns: 60         # longer sleep for block storage cache drain
+    failurePolicy: abortAll
+    timeoutPerRun: 2h
+
+  sweep:
+    blockSize:   ["4k", "8k", "64k", "128k", "1m"]   # primary axis: block size
+    rwMixWrite:  [0, 30, 100]                          # secondary axis: rw mix
+    ioPattern:   [randrw]                              # fixed: random mixed
+    runtime:     [60]
+    jobs:        [4]
+    ioDepth:     [4]
+    workSize:    ["2048g"]
+    directIO:    [1]
+    groupReporting: true
+    outputFormat: json
+
+  artifacts:
+    collectStats: true
+    compression: gzip
+    destination:
+      type: pvc
+      pvc:
+        storageClass: ""          # use cluster default for artifacts PVC
+        size: 20Gi
+    retention:
+      keepLastN: 20
+      deleteWithSuite: false
+
+---
+# Example 2: fio filesystem mode sweep (NFS or CephFS)
+# Sequential read/write throughput — classic backup/restore characterization
+# blockSize × ioPattern = 3 × 2 = 6 runs
+apiVersion: sherlock.io/v1alpha1
+kind: SherlockFioSuite
+metadata:
+  name: nfs-throughput-sweep
+  namespace: sherlock
+spec:
+  storage:
+    storageClass: nfs-csi
+    storageSize: 110Gi
+    storagePlugin: generic
+    volumeMode: Filesystem       # file mode — directory mount
+    fioPerWorker: 1
+    workerCount: 3
+
+  execution:
+    order: sequential
+    sleepBetweenRuns: 30
+    failurePolicy: continueAndReport
+    timeoutPerRun: 1h
+
+  sweep:
+    blockSize:  ["128k", "512k", "1m"]   # large blocks for throughput
+    rwMixWrite: [0]                       # read-only for throughput baseline
+    ioPattern:  [read, write]             # sequential read AND write
+    runtime:    [120]
+    jobs:       [4]
+    ioDepth:    [4]
+    workSize:   ["100g"]
+    directIO:   [1]
+    outputFormat: json
+
+  artifacts:
+    collectStats: true
+    compression: gzip
+    destination:
+      type: s3
+      s3:
+        endpoint: https://minio.internal.example.com
+        bucket: sherlock-fio-results
+        prefix: "runs/{{.SuiteName}}/{{.Timestamp}}/"
+        credentialsSecret: sherlock-s3-creds
+    retention:
+      ttlDays: 60
+      deleteWithSuite: false

--- a/operator/crds/examples/hammerdb-example.yaml
+++ b/operator/crds/examples/hammerdb-example.yaml
@@ -1,0 +1,43 @@
+# HammerDB TPC-C sweep on MSSQL
+# 3 × 2 = 6 runs, sequential, 30s sleep between each
+# Run names: mssql-vu-sweep-vu8-wh100-rm2-tm5, ...-tm10, ...-vu16-..., etc.
+---
+apiVersion: sherlock.io/v1alpha1
+kind: SherlockHammerDBSuite
+metadata:
+  name: mssql-vu-sweep
+  namespace: sherlock
+spec:
+  database:
+    type: mssql
+    instancesPerNode: 2
+    storageClass: lightbits-nvmeof
+    storageSize: 100Gi
+    storagePlugin: lightbits
+    resources:
+      requests: {cpu: "4", memory: "8Gi"}
+      limits:   {cpu: "8", memory: "16Gi"}
+    nodeSelector:
+      node-role: worker
+  execution:
+    order: sequential
+    sleepBetweenRuns: 30
+    failurePolicy: abortAll
+    timeoutPerRun: 30m
+  sweep:
+    virtualUsers: [8, 16, 32]
+    warehouses:   [100]
+    rampupMins:   [2]
+    testMins:     [5, 10]
+    allWarehouses: [false]
+  artifacts:
+    collectStats: true
+    compression: gzip
+    destination:
+      type: pvc
+      pvc:
+        storageClass: ""
+        size: 20Gi
+    retention:
+      keepLastN: 20
+      deleteWithSuite: false

--- a/operator/crds/examples/pgbench-example.yaml
+++ b/operator/crds/examples/pgbench-example.yaml
@@ -1,0 +1,42 @@
+# pgbench read/write ratio sweep on PostgreSQL
+# clients × readWriteRatio = 4 × 3 = 12 runs
+# Artifacts to S3 — no PVC required on cluster
+---
+apiVersion: sherlock.io/v1alpha1
+kind: SherlockPgbenchSuite
+metadata:
+  name: postgres-rw-sweep
+  namespace: sherlock
+spec:
+  database:
+    type: postgresql
+    instancesPerNode: 2
+    storageClass: standard
+    storageSize: 50Gi
+    storagePlugin: generic
+    partitionedTables: false
+  execution:
+    order: sequential
+    sleepBetweenRuns: 30
+    failurePolicy: continueAndReport
+    timeoutPerRun: 10m
+  sweep:
+    clients:        [1, 2, 8, 16]
+    threads:        [4]
+    readWriteRatio: [100, 70, 50]
+    scaleFactor:    [100]
+    duration:       [120]
+    protocol:       [simple]
+  artifacts:
+    collectStats: true
+    compression: gzip
+    destination:
+      type: s3
+      s3:
+        endpoint: https://s3.us-east-1.amazonaws.com
+        bucket: sherlock-benchmarks
+        prefix: "runs/{{.SuiteName}}/{{.Timestamp}}/"
+        credentialsSecret: sherlock-s3-creds
+    retention:
+      ttlDays: 90
+      deleteWithSuite: false

--- a/operator/crds/examples/sysbench-example.yaml
+++ b/operator/crds/examples/sysbench-example.yaml
@@ -1,0 +1,40 @@
+# sysbench thread sweep on MySQL
+# threads × testType = 4 × 2 = 8 runs
+# failurePolicy=retryN with retryLimit=2
+---
+apiVersion: sherlock.io/v1alpha1
+kind: SherlockSysbenchSuite
+metadata:
+  name: mysql-thread-sweep
+  namespace: sherlock
+spec:
+  database:
+    type: mysql
+    instancesPerNode: 2
+    storageClass: csi-block
+    storageSize: 50Gi
+    storagePlugin: generic
+  execution:
+    order: sequential
+    sleepBetweenRuns: 30
+    failurePolicy: retryN
+    retryLimit: 2
+    timeoutPerRun: 30m
+  sweep:
+    threads:        [4, 8, 16, 32]
+    tables:         [8]
+    tableSize:      [1000000]
+    testType:       [oltp_read_write, oltp_read_only]
+    duration:       [120]
+    reportInterval: 10
+  artifacts:
+    collectStats: true
+    compression: zstd
+    destination:
+      type: pvc
+      pvc:
+        storageClass: ""
+        size: 10Gi
+    retention:
+      keepLastN: 10
+      deleteWithSuite: false

--- a/operator/crds/examples/ycsb-example.yaml
+++ b/operator/crds/examples/ycsb-example.yaml
@@ -1,0 +1,35 @@
+# YCSB workload sweep on MongoDB
+# threads × workload = 3 × 3 = 9 runs
+# Local destination — pull with: kubectl sherlock pull mongo-workload-sweep ./results/
+---
+apiVersion: sherlock.io/v1alpha1
+kind: SherlockYCSBSuite
+metadata:
+  name: mongo-workload-sweep
+  namespace: sherlock
+spec:
+  database:
+    type: mongodb
+    instancesPerNode: 1
+    storageClass: fast-nvme
+    storageSize: 100Gi
+    storagePlugin: generic
+  execution:
+    order: sequential
+    sleepBetweenRuns: 30
+    failurePolicy: abortAll
+    timeoutPerRun: 1h
+  sweep:
+    threads:             [4, 8, 16]
+    workload:            [a, b, c]
+    recordCount:         [1000000]
+    operationCount:      [100000]
+    requestDistribution: [zipfian]
+    maxExecutionTime:    120
+  artifacts:
+    collectStats: true
+    compression: gzip
+    destination:
+      type: local
+      local:
+        ttlHours: 48


### PR DESCRIPTION
## Sherlock v2

This PR initiates the v2 rewrite of Sherlock, moving from bash-based orchestration to a Kubernetes operator model.

### What is in this PR

CRD schemas for four benchmark-specific Suite operators:

| CRD | Benchmark | Database |
|-----|-----------|----------|
| `SherlockHammerDBSuite` | HammerDB TPC-C | MSSQL, MySQL |
| `SherlockPgbenchSuite` | pgbench | PostgreSQL |
| `SherlockSysbenchSuite` | sysbench | MySQL, PostgreSQL |
| `SherlockYCSBSuite` | YCSB | MongoDB |

### Key design decisions

**Parameter sweep model** replaces nested bash for-loops. Each `spec.sweep` field accepts a list of values; the operator expands the cartesian product into individual runs:
```yaml
sweep:
  virtualUsers: [8, 16, 32]  # sweep axis
  testMins: [5, 10]          # sweep axis
  warehouses: [100]          # fixed param
# → 6 runs total
```

**Artifact destinations**: `pvc` | `s3` | `local` (`kubectl sherlock pull`)

**Storage plugin abstraction**: `generic` (iostat/vmstat, default) | `lightbits` | `odf` | `portworx`

**Failure policies**: `abortAll` | `retryN` | `continueAndReport`

**OCP-specific SCCs removed** — standard `PodSecurityContext` throughout, Kustomize overlay for OCP-specific patches.

### What comes next (subsequent PRs)
- kopf operator implementation (Python)
- Python stat parser replacing bash grep/awk
- `kubectl sherlock` CLI plugin
- Prometheus/Grafana observability layer

### Note
Existing bash scripts on `master` are untouched. This branch will be merged to `master` once the operator implementation is verified.